### PR TITLE
Add timestamp and commit-id for automated COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,5 @@
 srpm:
-	./build.sh srpm
+	./build.sh srpm --with-timestamp --with-commit-id
 	if [[ "${outdir}" != "" ]]; then \
 	    mv ${HOME}/build/ldapjdk/SRPMS/* ${outdir}; \
 	fi


### PR DESCRIPTION
To aid in copr automated builds, this patch creates
NVR based on timestamp and commit-id

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`