### PR TITLE
Provide a correct version within POM

### DIFF
--- a/ldapjdk.pom
+++ b/ldapjdk.pom
@@ -2,5 +2,5 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ldapjdk</groupId>
   <artifactId>ldapjdk</artifactId>
-  <version>4.20.0</version>
+  <version>@VERSION@</version>
 </project>

--- a/ldapjdk.spec
+++ b/ldapjdk.spec
@@ -122,6 +122,7 @@ pushd $RPM_BUILD_ROOT%{_javadir}-1.3.0
 popd
 
 mkdir -p %{buildroot}%{_mavenpomdir}
+sed -i 's/@VERSION@/%{version}/g' %{name}.pom
 install -pm 644 %{name}.pom %{buildroot}%{_mavenpomdir}/JPP-%{name}.pom
 %add_maven_depmap JPP-%{name}.pom %{name}.jar -a "ldapsdk:ldapsdk"
 


### PR DESCRIPTION
The product's version was hardcoded into the POM.
Thus, even the newer version was packaged the POM
stays exactly the same.
