### PR TITLE
Update Maven project

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,87 @@
+name: Build Tests
+
+on: [push, pull_request]
+
+jobs:
+  init:
+    name: Initializing Workflow
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Initialize workflow
+        id: init
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
+        run: |
+          tests/bin/init-workflow.sh
+
+  build-test:
+    name: Build Test
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: fedora:${{ matrix.os }}
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        dnf install -y dnf-plugins-core maven
+        dnf copr enable -y ${{ needs.init.outputs.repo }}
+        dnf builddep -y --spec ldapjdk.spec
+
+    - name: Build LDAP JDK with Ant
+      run: |
+        ./build.sh
+
+    - name: Install JSS into Maven repo
+      run: |
+        mvn install:install-file \
+            -Dfile=/usr/lib/java/jss.jar \
+            -DgroupId=org.dogtagpki \
+            -DartifactId=jss \
+            -Dversion=5.3.0-SNAPSHOT \
+            -Dpackaging=jar \
+            -DgeneratePom=true
+
+    - name: Build LDAP JDK with Maven
+      run: |
+        mvn package
+
+    - name: Compare ldapjdk.jar
+      run: |
+        jar tvf ~/build/ldapjdk/packages/ldapjdk.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf java-sdk/ldapjdk/target/ldapjdk-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out
+
+    - name: Compare ldapbeans.jar
+      run: |
+        jar tvf ~/build/ldapjdk/packages/ldapbeans.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf java-sdk/ldapbeans/target/ldapbeans-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out
+
+    - name: Compare ldapfilter.jar
+      run: |
+        jar tvf ~/build/ldapjdk/packages/ldapfilt.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf java-sdk/ldapfilter/target/ldapfilter-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out
+
+    - name: Compare ldapsp.jar
+      run: |
+        jar tvf ~/build/ldapjdk/packages/ldapsp.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf java-sdk/ldapsp/target/ldapsp-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out
+
+    - name: Compare ldaptools.jar
+      run: |
+        jar tvf ~/build/ldapjdk/packages/ldaptools.jar | awk '{print $8;}' | sort | tee ant.out
+        jar tvf java-sdk/ldaptools/target/ldaptools-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        diff ant.out maven.out

--- a/java-sdk/ldapbeans/pom.xml
+++ b/java-sdk/ldapbeans/pom.xml
@@ -4,36 +4,49 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldapbeans</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
 
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
-            <groupId>org.mozilla</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>jss</artifactId>
-            <version>4.8.0-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>4.22.1-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/java-sdk/ldapfilter/pom.xml
+++ b/java-sdk/ldapfilter/pom.xml
@@ -4,30 +4,43 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldapfilter</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
 
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>4.22.1-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/java-sdk/ldapjdk/pom.xml
+++ b/java-sdk/ldapjdk/pom.xml
@@ -4,30 +4,43 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldapjdk</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
 
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
-            <groupId>org.mozilla</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>jss</artifactId>
-            <version>4.8.0-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/java-sdk/ldapsp/pom.xml
+++ b/java-sdk/ldapsp/pom.xml
@@ -4,30 +4,43 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldapsp</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
 
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>4.22.1-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/java-sdk/ldaptools/pom.xml
+++ b/java-sdk/ldaptools/pom.xml
@@ -4,36 +4,50 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldaptools</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
 
     <dependencies>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
-            <groupId>org.mozilla</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>jss</artifactId>
-            <version>4.8.0-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
+            <groupId>org.dogtagpki</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>4.22.1-SNAPSHOT</version>
+            <version>5.3.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <groupId>org.dogtagpki</groupId>
     <artifactId>ldap-sdk</artifactId>
-    <version>4.22.1-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
The `pom.xml` files have been updated as follows:

- The group ID has been changed to `org.dogtagpki` so that all projects belong to the same group
- The LDAP SDK version has been updated to match RPM spec version
- The JSS version has been updated to match the version in JSS master branch
- The dependency versions have been updated to match the packages available on Fedora

A new test has been added to build with Maven and compare the artifacts with the ones created by Ant. The comparison excludes `META-INF/maven/` since that folder is only available in Maven artifacts.
