### PR TITLE
Update Fedora container and COPR repository

### DIFF
--- a/.github/workflows/ds-tests.yml
+++ b/.github/workflows/ds-tests.yml
@@ -6,19 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:34
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
-          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export current=$(cat /etc/fedora-release | awk '{ print $3 }')
           export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-          echo "Running CI against Fedora $previous and $latest"
+          echo "Running CI against Fedora $previous and $current"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$current\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi
@@ -28,7 +28,7 @@ jobs:
     needs: init
     runs-on: ubuntu-latest
     env:
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/ldapjdk
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -6,19 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:34
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
-          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export current=$(cat /etc/fedora-release | awk '{ print $3 }')
           export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1 }')
-          echo "Running CI against Fedora $previous and $latest"
+          echo "Running CI against Fedora $previous and $current"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$current\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi
@@ -28,7 +28,7 @@ jobs:
     needs: init
     runs-on: ubuntu-latest
     env:
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/ldapjdk
-      COPR_REPO: "@pki/10.11"
+      COPR_REPO: "@pki/10.12"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-ARG OS_VERSION="latest"
-ARG COPR_REPO="@pki/10.11"
+ARG OS_VERSION="34"
+ARG COPR_REPO="@pki/10.12"
 
 ################################################################################
 FROM registry.fedoraproject.org/fedora:$OS_VERSION AS ldapjdk-builder


### PR DESCRIPTION
LDAP SDK 4.23 is only supported up to Fedora 34 for PKI 10.12, so the Fedora container has been changed to `fedora:34` and the COPR repository has been changed to `@pki/10.12`.