### PR TITLE
Fix LDAPException messages

### DIFF
--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPConnection.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPConnection.java
@@ -5206,9 +5206,11 @@ public class LDAPConnection implements Cloneable, Serializable {
               throw new LDAPReferralException ( "referral", resultCode,
                                                 response.getErrorMessage() );
           } else {
-              throw new LDAPException ( "error result", resultCode,
-                                        response.getErrorMessage(),
-                                        response.getMatchedDN() );
+              throw new LDAPException(
+                      LDAPException.resultCodeToString(resultCode),
+                      resultCode,
+                      response.getErrorMessage(),
+                      response.getMatchedDN());
           }
 
       } else if ( m.getProtocolOp() instanceof JDAPSearchResultReference ) {

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPException.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPException.java
@@ -1115,11 +1115,6 @@ public class LDAPException extends Exception
         if ( (matchedDN != null) && (matchedDN.length() > 0) ) {
             str += "; matchedDN = " + matchedDN;
         }
-        String errorStr = null;
-        if ( ((errorStr = resultCodeToString(m_locale)) != null) &&
-             (errorStr.length() > 0) ) {
-            str += "; " + errorStr;
-        }
         if ( (rootException != null) && (rootException != this) ) {
             str += " [Root exception is " + rootException.toString() + "]";
         }

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
@@ -4926,9 +4926,11 @@ public class LDAPConnection
               throw new LDAPReferralException ("referral", resultCode,
                                                response.getErrorMessage());
           } else {
-              throw new LDAPException ("error result", resultCode,
-                response.getErrorMessage(),
-                response.getMatchedDN());
+              throw new LDAPException(
+                      LDAPException.errorCodeToString(resultCode),
+                      resultCode,
+                      response.getErrorMessage(),
+                      response.getMatchedDN());
           }
 
       } else if (m.getProtocolOp() instanceof JDAPSearchResultReference) {

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPException.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPException.java
@@ -839,10 +839,6 @@ public class LDAPException extends java.lang.Exception
         if ( (matchedDN != null) && (matchedDN.length() > 0) ) {
             str += "; matchedDN = " + matchedDN;
         }
-        String  errorStr = errorCodeToString(m_locale);
-        if ((errorStr != null) && (errorStr.length() > 0)) {
-            str += "; " + errorStr;
-        }
         if (extraMessage != null) {
             str += "; " + extraMessage;
         }

--- a/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/EventService.java
+++ b/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/EventService.java
@@ -304,8 +304,13 @@ class EventService implements Runnable{
             return; // ignore referral
         }
 
-        LDAPException ex = new LDAPException( "error result",rsp.getResultCode(),
-                           rsp.getErrorMessage(), rsp.getMatchedDN());
+        int resultCode = rsp.getResultCode();
+        LDAPException ex = new LDAPException(
+                LDAPException.errorCodeToString(resultCode),
+                resultCode,
+                rsp.getErrorMessage(),
+                rsp.getMatchedDN());
+
         NamingException nameEx = ExceptionMapper.getNamingException(ex);
         dispatchEvent(new NamingExceptionEvent(ee.ctx, nameEx), ee);
     }


### PR DESCRIPTION
In order to help troubleshooting some `LDAPException`s have been modified to use the standard LDAP error message which is generated from the LDAP return code instead of a generic "error result" message. The `LDAPException.toString()` has
been modified to no longer append the LDAP error message since now it has been included in the exception message.
