### PR TITLE
Replace deprecated primitive-to-object conversions

### DIFF
--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPCache.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPCache.java
@@ -458,8 +458,7 @@ public class LDAPCache implements Serializable {
             for (int i=0; i<serverControls.length; i++) {
                 LDAPControl ctrl = serverControls[i];
                 long val = getCRC32(ctrl.getValue());
-                objID[i] = ctrl.getID() + ctrl.isCritical() +
-                    new Long(val).toString();
+                objID[i] = ctrl.getID() + ctrl.isCritical() + val;
             }
             key = key + appendString(objID);
         }  else {
@@ -470,7 +469,7 @@ public class LDAPCache implements Serializable {
         if ( m_debug ) {
             System.out.println("key="+val + " for "+key);
         }
-        return new Long(val);
+        return val;
     }
 
     /**
@@ -584,7 +583,7 @@ public class LDAPCache implements Serializable {
         m_cache.put(key, v);
         Vector<Long> element = new Vector<>(2);
         element.addElement(key);
-        element.addElement(new Long(System.currentTimeMillis()));
+        element.addElement(System.currentTimeMillis());
         m_orderedStruct.addElement(element);
 
         // Start TTL Timer if first entry is added

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPConnThread.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPConnThread.java
@@ -255,8 +255,7 @@ class LDAPConnThread extends Thread {
             if ( !(request instanceof JDAPAbandonRequest ||
                    request instanceof JDAPUnbindRequest) ) {
                 /* Only worry about toNotify if we expect a response... */
-                this._requests.put( new Integer( msg.getMessageID()),
-                                    queue );
+                this._requests.put( msg.getMessageID(), queue );
                 /* Notify the backlog checker that there may be another
                    outstanding request */
                 resultRetrieved();
@@ -538,7 +537,7 @@ class LDAPConnThread extends Thread {
      * @param msg New message from LDAP server
      */
     private void processResponse( LDAPMessage msg, int size ) {
-        Integer messageID = new Integer( msg.getMessageID() );
+        Integer messageID = msg.getMessageID();
         LDAPMessageQueueImpl l =
             (LDAPMessageQueueImpl)_requests.get( messageID );
         if ( l == null ) {
@@ -590,7 +589,7 @@ class LDAPConnThread extends Thread {
      */
     private synchronized void cacheSearchResult( LDAPSearchQueue l,
                                                  LDAPMessage msg, int size ) {
-        Integer messageID = new Integer( msg.getMessageID() );
+        Integer messageID = msg.getMessageID();
         Long key = l.getKey();
         Vector<Object> v = null;
 
@@ -605,7 +604,7 @@ class LDAPConnThread extends Thread {
             v = _messages.get( messageID );
             if ( v == null ) {
                 _messages.put( messageID, v = new Vector<>() );
-                v.addElement( new Long(0) );
+                v.addElement( 0L );
             }
 
             // Return if the entry size is -1, i.e. caching is disabled
@@ -624,12 +623,12 @@ class LDAPConnThread extends Thread {
             // by setting the entry size to -1.
             if ( entrySize > _cache.getSize() ) {
                 v.removeAllElements();
-                v.addElement( new Long(-1L) );
+                v.addElement( -1L );
                 return;
             }
 
             // update the lump sum located in the first element of the vector
-            v.setElementAt( new Long(entrySize), 0 );
+            v.setElementAt( entrySize, 0 );
 
             // convert LDAPMessage object into LDAPEntry which is stored to the
             // end of the Vector
@@ -646,7 +645,7 @@ class LDAPConnThread extends Thread {
             else {
                 v.removeAllElements();
             }
-            v.addElement( new Long(-1L) );
+            v.addElement( -1L );
 
         } else if ( msg instanceof LDAPResponse ) {
 
@@ -662,7 +661,7 @@ class LDAPConnThread extends Thread {
                 // server
                 if ( v == null ) {
                     v = new Vector<>();
-                    v.addElement(new Long(0));
+                    v.addElement( 0L );
                 }
 
                 // add the new entry if the entry size is not -1 (caching
@@ -685,10 +684,10 @@ class LDAPConnThread extends Thread {
         }
 
         LDAPMessageQueueImpl l =
-            (LDAPMessageQueueImpl)_requests.remove( new Integer(id) );
+            (LDAPMessageQueueImpl)_requests.remove( id );
         // Clean up cache if enabled
         if ( _messages != null ) {
-            _messages.remove( new Integer(id) );
+            _messages.remove( id );
         }
         if ( l != null ) {
             l.removeRequest( id );
@@ -711,7 +710,7 @@ class LDAPConnThread extends Thread {
                                                    LDAPException.OTHER ) );
             return null;
         }
-        return _requests.put( new Integer(id), toNotify );
+        return _requests.put( id, toNotify );
     }
 
     /**

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPConnection.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPConnection.java
@@ -512,11 +512,11 @@ public class LDAPConnection implements Cloneable, Serializable {
     /**
      * Properties
      */
-    private final static Float SdkVersion = new Float(4.14f);
-    private final static Float ProtocolVersion = new Float(3.0f);
+    private final static Float SdkVersion = 4.14f;
+    private final static Float ProtocolVersion = 3.0f;
     private final static String SecurityVersion = new String("none,simple,sasl");
-    private final static Float MajorVersion = new Float(4.0f);
-    private final static Float MinorVersion = new Float(0.14f);
+    private final static Float MajorVersion = 4.0f;
+    private final static Float MinorVersion = 0.14f;
     private final static String DELIM = "#";
     private final static String PersistSearchPackageName =
       "org.ietf.ldap.controls.LDAPPersistSearchControl";
@@ -4383,7 +4383,7 @@ public class LDAPConnection implements Cloneable, Serializable {
      */
     public Object getOption( int option ) throws LDAPException {
         if (option == LDAPConnection.PROTOCOL_VERSION) {
-            return new Integer(_protocolVersion);
+            return _protocolVersion;
         }
 
         return getOption(option, _defaultConstraints);
@@ -4393,23 +4393,23 @@ public class LDAPConnection implements Cloneable, Serializable {
         throws LDAPException {
         switch (option) {
             case LDAPConnection.DEREF:
-              return new Integer (cons.getDereference());
+              return cons.getDereference();
             case LDAPConnection.SIZELIMIT:
-              return new Integer (cons.getMaxResults());
+              return cons.getMaxResults();
             case LDAPConnection.TIMELIMIT:
-              return new Integer (cons.getServerTimeLimit());
+              return cons.getServerTimeLimit();
             case LDAPConnection.REFERRALS:
-              return new Boolean (cons.getReferralFollowing());
+              return cons.getReferralFollowing();
             case LDAPConnection.REFERRALS_REBIND_PROC:
               return cons.getReferralHandler();
             case LDAPConnection.REFERRALS_HOP_LIMIT:
-              return new Integer (cons.getHopLimit());
+              return cons.getHopLimit();
             case LDAPConnection.BATCHSIZE:
-              return new Integer (cons.getBatchSize());
+              return cons.getBatchSize();
             case LDAPConnection.SERVERCONTROLS:
               return cons.getControls();
             case MAXBACKLOG:
-              return new Integer (cons.getMaxBacklog());
+              return cons.getMaxBacklog();
             default:
               throw new LDAPException ( "invalid option",
                                         LDAPException.PARAM_ERROR );
@@ -5310,16 +5310,14 @@ public class LDAPConnection implements Cloneable, Serializable {
         // Set the same connection setup failover policy as for this connection
         connection.setConnSetupDelay( getConnSetupDelay() );
 
-        connection.setOption( REFERRALS, new Boolean(true) );
+        connection.setOption( REFERRALS, true );
         connection.setOption( REFERRALS_REBIND_PROC,
                               cons.getReferralHandler() );
 
         // need to set the protocol version which gets passed to connection
-        connection.setOption( PROTOCOL_VERSION,
-                              new Integer(_protocolVersion) );
+        connection.setOption( PROTOCOL_VERSION, _protocolVersion );
 
-        connection.setOption( REFERRALS_HOP_LIMIT,
-                              new Integer(cons.getHopLimit()-1) );
+        connection.setOption( REFERRALS_HOP_LIMIT, cons.getHopLimit()-1 );
 
         try {
             connection.connect( connectList, LDAPConnection.DEFAULT_PORT );
@@ -5580,7 +5578,7 @@ public class LDAPConnection implements Cloneable, Serializable {
                     break;
                 case JDAPProtocolOp.COMPARE_REQUEST:
                     boolean bool = connection.compare( dn, attr, cons );
-                    results.addElement( new Boolean(bool) );
+                    results.addElement( bool );
                     break;
                 default:
                     /* impossible */

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPControl.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPControl.java
@@ -361,7 +361,7 @@ public class LDAPControl implements Cloneable, Serializable {
             return new LDAPControl(oid, critical, value);
         }
 
-        Object[] oparams = { oid, new Boolean(critical), value } ;
+        Object[] oparams = { oid, critical, value } ;
         LDAPControl returnControl = null;
         try {
             returnControl = (LDAPControl)creator.newInstance(oparams);

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPSSLSocketFactory.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPSSLSocketFactory.java
@@ -301,7 +301,7 @@ public class LDAPSSLSocketFactory
                      (params[1].getName().equals("int")) ) {
                     Object[] args = new Object[2];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     s = (Socket)(m[i].newInstance(args));
                     return s;
                 } else if ( (_cipherSuites != null) && (params.length == 3) &&
@@ -310,7 +310,7 @@ public class LDAPSSLSocketFactory
                      (params[2].getName().equals(cipherClassName)) ) {
                     Object[] args = new Object[3];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     args[2] = _cipherSuites;
                     s = (Socket)(m[i].newInstance(args));
                     return s;

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPSSLSocketWrapFactory.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPSSLSocketWrapFactory.java
@@ -192,7 +192,7 @@ class LDAPSSLSocket extends Socket {
                     (params[1].getName().equals("int"))) {
                     Object[] args = new Object[2];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     _socket = (m[i].newInstance(args));
                     return;
                 }
@@ -234,7 +234,7 @@ class LDAPSSLSocket extends Socket {
                     (params[2].getName().equals(cipherClassName))) {
                     Object[] args = new Object[3];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     args[2] = cipherSuites;
                     _socket = (m[i].newInstance(args));
                     return;
@@ -284,7 +284,7 @@ class LDAPSSLSocket extends Socket {
     public void close(boolean wait) throws IOException {
         try {
             Object[] args = new Object[1];
-            args[0] = new Boolean(wait);
+            args[0] = wait;
             invokeMethod(_socket, "close", args);
         } catch (LDAPException e) {
             printDebug(e.toString());

--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPSchema.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPSchema.java
@@ -280,8 +280,7 @@ public class LDAPSchema implements Serializable {
             _contentRules.put( name, (LDAPDITContentRuleSchema) el );
         } else if ( el instanceof LDAPDITStructureRuleSchema ) {
             _structureRulesByName.put( name, (LDAPDITStructureRuleSchema) el );
-            _structureRulesById.put( new Integer(
-                ((LDAPDITStructureRuleSchema)el).getRuleID() ), (LDAPDITStructureRuleSchema) el );
+            _structureRulesById.put( ((LDAPDITStructureRuleSchema)el).getRuleID(), (LDAPDITStructureRuleSchema) el );
         }
     }
 
@@ -390,7 +389,7 @@ public class LDAPSchema implements Serializable {
      * the rule, or <CODE>null</CODE> if not found.
      */
     public LDAPDITStructureRuleSchema getDITStructureRuleSchema( int ID ) {
-        return _structureRulesById.get( new Integer( ID ) );
+        return _structureRulesById.get( ID );
     }
 
     /**
@@ -595,8 +594,7 @@ public class LDAPSchema implements Serializable {
             _contentRules.put( name, (LDAPDITContentRuleSchema) el );
         } else if ( el instanceof LDAPDITStructureRuleSchema ) {
             _structureRulesByName.put( name, (LDAPDITStructureRuleSchema) el );
-            _structureRulesById.put( new Integer(
-                ((LDAPDITStructureRuleSchema)el).getRuleID() ), (LDAPDITStructureRuleSchema) el );
+            _structureRulesById.put( ((LDAPDITStructureRuleSchema)el).getRuleID(), (LDAPDITStructureRuleSchema) el );
         }
     }
 
@@ -657,8 +655,7 @@ public class LDAPSchema implements Serializable {
             _contentRules.remove( name );
         } else if ( el instanceof LDAPDITStructureRuleSchema ) {
             _structureRulesByName.remove( name );
-            _structureRulesById.remove( new Integer(
-                ((LDAPDITStructureRuleSchema)el).getRuleID() ) );
+            _structureRulesById.remove( ((LDAPDITStructureRuleSchema)el).getRuleID() );
         }
     }
 

--- a/java-sdk/ietfldap/org/ietf/ldap/ber/stream/BERObjectId.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/ber/stream/BERObjectId.java
@@ -95,21 +95,19 @@ public class BERObjectId extends BERElement {
 
         contents_length -= contents_read[0];
         if (sub_id < 40)
-            oid.addElement(new Integer(0));
+            oid.addElement(0);
         else if (sub_id < 80)
-            oid.addElement(new Integer(1));
+            oid.addElement(1);
         else
-            oid.addElement(new Integer(2));
-        oid.addElement(new Integer(
-            sub_id - (((Integer)oid.elementAt(
-                oid.size()-1)).intValue() * 40)));
+            oid.addElement(2);
+        oid.addElement(sub_id - (((Integer)oid.elementAt(oid.size()-1)).intValue() * 40));
 
         while (contents_length > 0) {
             contents_read[0] = 0;
             sub_id = readSubIdentifier(stream, contents_read);
 
             contents_length -= contents_read[0];
-            oid.addElement(new Integer(sub_id));
+            oid.addElement(sub_id);
         }
         m_value = new int[oid.size()];
         for (int i = 0; i<oid.size(); i++)

--- a/java-sdk/ldapfilter/src/main/java/netscape/ldap/util/LDAPFilter.java
+++ b/java-sdk/ldapfilter/src/main/java/netscape/ldap/util/LDAPFilter.java
@@ -324,17 +324,13 @@ public class LDAPFilter implements Cloneable {
                         case '7':
                         case '8':
                         case '9':
-                            int nValue = Integer.parseInt
-                                ( new Character
-                                  (cFilterTemplate[i]).toString() );
+                            int nValue = Integer.parseInt( String.valueOf(cFilterTemplate[i]) );
                             nValue--;
                             i++;
                             if ( cFilterTemplate[i] == '-' ) {
                                 i++;
                                 if ( Character.isDigit ( cFilterTemplate[i] )) {
-                                int nValue2 = Integer.parseInt
-                                    ( new Character
-                                    (cFilterTemplate[i]).toString() );
+                                int nValue2 = Integer.parseInt( String.valueOf(cFilterTemplate[i]) );
                                 nValue2--;
                                 for ( int j = nValue; j <= nValue2; j++ ) {
                                     sbFilter.append ( aValues[j] );

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPCache.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPCache.java
@@ -462,7 +462,7 @@ public class LDAPCache implements Serializable {
             for (int i=0; i<serverControls.length; i++) {
                 LDAPControl ctrl = serverControls[i];
                 long val = getCRC32(ctrl.getValue());
-                objID[i] = ctrl.getID() + ctrl.isCritical() + new Long(val).toString();
+                objID[i] = ctrl.getID() + ctrl.isCritical() + val;
             }
             key = key + appendString(objID);
         }
@@ -476,7 +476,7 @@ public class LDAPCache implements Serializable {
             for (int i=0; i<clientControls.length; i++) {
                 LDAPControl ctrl = clientControls[i];
                 long val = getCRC32(ctrl.getValue());
-                objID[i] = ctrl.getID() + ctrl.isCritical() + new Long(val).toString();
+                objID[i] = ctrl.getID() + ctrl.isCritical() + val;
 
             }
             key = key + appendString(objID);
@@ -488,7 +488,7 @@ public class LDAPCache implements Serializable {
         if(m_debug) {
             System.out.println("key="+val + " for "+key);
         }
-        return new Long(val);
+        return val;
     }
 
     /**
@@ -604,7 +604,7 @@ public class LDAPCache implements Serializable {
         m_cache.put(key, v);
         Vector<Long> element = new Vector<>(2);
         element.addElement(key);
-        element.addElement(new Long(System.currentTimeMillis()));
+        element.addElement(System.currentTimeMillis());
         m_orderedStruct.addElement(element);
 
         // Start TTL Timer if first entry is added

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnThread.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnThread.java
@@ -288,7 +288,7 @@ class LDAPConnThread implements Runnable {
 
         if ( toNotify != null ) {
             /* Only worry about toNotify if we expect a response... */
-            m_requests.put (new Integer (msg.getMessageID()), toNotify);
+            m_requests.put (msg.getMessageID(), toNotify);
 
             /* Notify the backlog checker that there may be another outstanding
                request */
@@ -643,7 +643,7 @@ class LDAPConnThread implements Runnable {
      * @param msg New message from LDAP server
      */
     private void processResponse (LDAPMessage msg, int size) {
-        Integer messageID = new Integer (msg.getMessageID());
+        Integer messageID = msg.getMessageID();
         LDAPMessageQueue l = m_requests.get (messageID);
         if (l == null) {
             return; /* nobody is waiting for this response (!) */
@@ -707,7 +707,7 @@ class LDAPConnThread implements Runnable {
      * the entry size to -1.
      */
     private synchronized void cacheSearchResult (LDAPSearchListener l, LDAPMessage msg, int size) {
-        Integer messageID = new Integer (msg.getMessageID());
+        Integer messageID = msg.getMessageID();
         Long key = l.getKey();
         Vector<Object> v = null;
 
@@ -721,7 +721,7 @@ class LDAPConnThread implements Runnable {
             v = m_messages.get(messageID);
             if (v == null) {
                 m_messages.put(messageID, v = new Vector<Object>());
-                v.addElement(new Long(0));
+                v.addElement(0L);
             }
 
             // Return if the entry size is -1, i.e. the caching is disabled
@@ -740,12 +740,12 @@ class LDAPConnThread implements Runnable {
             // by setting the entry size to -1.
             if (entrySize > m_cache.getSize()) {
                 v.removeAllElements();
-                v.addElement(new Long(-1L));
+                v.addElement(-1L);
                 return;
             }
 
             // update the lump sum located in the first element of the vector
-            v.setElementAt(new Long(entrySize), 0);
+            v.setElementAt(entrySize, 0);
 
             // convert LDAPMessage object into LDAPEntry which is stored to the
             // end of the Vector
@@ -762,7 +762,7 @@ class LDAPConnThread implements Runnable {
             else {
                 v.removeAllElements();
             }
-            v.addElement(new Long(-1L));
+            v.addElement(-1L);
 
         } else if (msg instanceof LDAPResponse) {
 
@@ -778,7 +778,7 @@ class LDAPConnThread implements Runnable {
                 // server
                 if (v == null) {
                     v = new Vector<Object>();
-                    v.addElement(new Long(0));
+                    v.addElement(0L);
                 }
 
                 // add the new entry if the entry size is not -1 (caching diabled)
@@ -800,10 +800,10 @@ class LDAPConnThread implements Runnable {
             return;
         }
 
-        LDAPMessageQueue l = m_requests.remove(new Integer(id));
+        LDAPMessageQueue l = m_requests.remove(id);
         // Clean up cache if enabled
         if (m_messages != null) {
-            m_messages.remove(new Integer(id));
+            m_messages.remove(id);
         }
         if (l != null) {
             l.removeRequest(id);
@@ -826,7 +826,7 @@ class LDAPConnThread implements Runnable {
                                                            LDAPException.SERVER_DOWN));
             return null;
         }
-        return m_requests.put (new Integer (id), toNotify);
+        return m_requests.put (id, toNotify);
     }
 
     /**

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
@@ -291,11 +291,11 @@ public class LDAPConnection
     /**
      * Properties
      */
-    private final static Float SdkVersion = new Float(4.18f);
-    private final static Float ProtocolVersion = new Float(3.0f);
+    private final static Float SdkVersion = 4.18f;
+    private final static Float ProtocolVersion = 3.0f;
     private final static String SecurityVersion = new String("none,simple,sasl");
-    private final static Float MajorVersion = new Float(4.0f);
-    private final static Float MinorVersion = new Float(0.18f);
+    private final static Float MajorVersion = 4.0f;
+    private final static Float MinorVersion = 0.18f;
     private final static String DELIM = "#";
     private final static String PersistSearchPackageName =
       "netscape.ldap.controls.LDAPPersistSearchControl";
@@ -4280,7 +4280,7 @@ public class LDAPConnection
      */
     public Object getOption( int option ) throws LDAPException {
         if (option == LDAPv2.PROTOCOL_VERSION) {
-            return new Integer(m_protocolVersion);
+            return m_protocolVersion;
         }
 
         return getOption(option, m_defaultConstraints);
@@ -4290,27 +4290,27 @@ public class LDAPConnection
         throws LDAPException {
         switch (option) {
             case LDAPv2.DEREF:
-              return new Integer (cons.getDereference());
+              return cons.getDereference();
             case LDAPv2.SIZELIMIT:
-              return new Integer (cons.getMaxResults());
+              return cons.getMaxResults();
             case LDAPv2.TIMELIMIT:
-              return new Integer (cons.getServerTimeLimit());
+              return cons.getServerTimeLimit();
             case LDAPv2.REFERRALS:
-              return new Boolean (cons.getReferrals());
+              return cons.getReferrals();
             case LDAPv2.REFERRALS_REBIND_PROC:
               return cons.getRebindProc();
             case LDAPv2.BIND:
               return cons.getBindProc();
             case LDAPv2.REFERRALS_HOP_LIMIT:
-              return new Integer (cons.getHopLimit());
+              return cons.getHopLimit();
             case LDAPv2.BATCHSIZE:
-              return new Integer (cons.getBatchSize());
+              return cons.getBatchSize();
             case LDAPv3.CLIENTCONTROLS:
               return cons.getClientControls();
             case LDAPv3.SERVERCONTROLS:
               return cons.getServerControls();
             case MAXBACKLOG:
-              return new Integer (cons.getMaxBacklog());
+              return cons.getMaxBacklog();
             default:
               throw new LDAPException ( "invalid option",
                                         LDAPException.PARAM_ERROR );
@@ -4983,7 +4983,7 @@ public class LDAPConnection
         // Set the same connection setup failover policy as for this connection
         connection.setConnSetupDelay(getConnSetupDelay());
 
-        connection.setOption(REFERRALS, new Boolean(true));
+        connection.setOption(REFERRALS, true);
         connection.setOption(REFERRALS_REBIND_PROC, cons.getRebindProc());
         connection.setOption(BIND, cons.getBindProc());
 
@@ -4993,11 +4993,9 @@ public class LDAPConnection
         }
 
         // need to set the protocol version which gets passed to connection
-        connection.setOption(PROTOCOL_VERSION,
-                              new Integer(m_protocolVersion));
+        connection.setOption(PROTOCOL_VERSION, m_protocolVersion);
 
-        connection.setOption(REFERRALS_HOP_LIMIT,
-                              new Integer(cons.getHopLimit()-1));
+        connection.setOption(REFERRALS_HOP_LIMIT, cons.getHopLimit()-1 );
 
         try {
             connection.connect (refList);
@@ -5266,7 +5264,7 @@ public class LDAPConnection
                     break;
                 case JDAPProtocolOp.COMPARE_REQUEST:
                     boolean bool = connection.compare(dn, attr, cons);
-                    results.addElement(new Boolean(bool));
+                    results.addElement(bool);
                     break;
                 default:
                     /* impossible */

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPControl.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPControl.java
@@ -364,7 +364,7 @@ public class LDAPControl implements Cloneable, java.io.Serializable {
 	    return new LDAPControl(oid, critical, value);
 	}
 
-	Object[] oparams = { oid, new Boolean(critical), value } ;
+	Object[] oparams = { oid, critical, value } ;
 	LDAPControl returnControl = null;
 	try {
 	    returnControl = (LDAPControl)creator.newInstance(oparams);

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSSLSocketFactory.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSSLSocketFactory.java
@@ -300,7 +300,7 @@ public class LDAPSSLSocketFactory
                      (params[1].getName().equals("int")) ) {
                     Object[] args = new Object[2];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     s = (Socket)(m[i].newInstance(args));
                     return s;
                 } else if ( (m_cipherSuites != null) && (params.length == 3) &&
@@ -309,7 +309,7 @@ public class LDAPSSLSocketFactory
                      (params[2].getName().equals(cipherClassName)) ) {
                     Object[] args = new Object[3];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     args[2] = m_cipherSuites;
                     s = (Socket)(m[i].newInstance(args));
                     return s;

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSSLSocketWrapFactory.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSSLSocketWrapFactory.java
@@ -192,7 +192,7 @@ class LDAPSSLSocket extends Socket {
                     (params[1].getName().equals("int"))) {
                     Object[] args = new Object[2];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     m_socket = (m[i].newInstance(args));
                     return;
                 }
@@ -234,7 +234,7 @@ class LDAPSSLSocket extends Socket {
                     (params[2].getName().equals(cipherClassName))) {
                     Object[] args = new Object[3];
                     args[0] = host;
-                    args[1] = new Integer(port);
+                    args[1] = port;
                     args[2] = cipherSuites;
                     m_socket = (m[i].newInstance(args));
                     return;
@@ -284,7 +284,7 @@ class LDAPSSLSocket extends Socket {
     public void close(boolean wait) throws IOException {
         try {
             Object[] args = new Object[1];
-            args[0] = new Boolean(wait);
+            args[0] = wait;
             invokeMethod(m_socket, "close", args);
         } catch (LDAPException e) {
             printDebug(e.toString());

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSchema.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSchema.java
@@ -356,7 +356,7 @@ public class LDAPSchema implements java.io.Serializable {
     public void addDITStructureRule( LDAPDITStructureRuleSchema rule ) {
         String name = rule.getName().toLowerCase();
         structureRulesByName.put( name, rule );
-        structureRulesById.put( new Integer( rule.getRuleID() ), rule );
+        structureRulesById.put( rule.getRuleID(), rule );
     }
 
     /**
@@ -532,7 +532,7 @@ public class LDAPSchema implements java.io.Serializable {
      * the rule, or <CODE>null</CODE> if not found.
      */
     public LDAPDITStructureRuleSchema getDITStructureRule( int ID ) {
-        return structureRulesById.get( new Integer( ID ) );
+        return structureRulesById.get( ID );
     }
 
     /**

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/ber/stream/BERObjectId.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/ber/stream/BERObjectId.java
@@ -95,21 +95,19 @@ public class BERObjectId extends BERElement {
 
         contents_length -= contents_read[0];
         if (sub_id < 40)
-            oid.addElement(new Integer(0));
+            oid.addElement(0);
         else if (sub_id < 80)
-            oid.addElement(new Integer(1));
+            oid.addElement(1);
         else
-            oid.addElement(new Integer(2));
-        oid.addElement(new Integer(
-            sub_id - (((Integer)oid.elementAt(
-                oid.size()-1)).intValue() * 40)));
+            oid.addElement(2);
+        oid.addElement(sub_id - (((Integer)oid.elementAt(oid.size()-1)).intValue() * 40));
 
         while (contents_length > 0) {
             contents_read[0] = 0;
             sub_id = readSubIdentifier(stream, contents_read);
 
             contents_length -= contents_read[0];
-            oid.addElement(new Integer(sub_id));
+            oid.addElement(sub_id);
         }
         m_value = new int[oid.size()];
         for (int i = 0; i<oid.size(); i++)

--- a/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/EventService.java
+++ b/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/EventService.java
@@ -450,7 +450,7 @@ class EventService implements Runnable{
 
         // Pass the change log number as event's change info
         // If the change log number is not present the value is -1
-        changeInfo = new Integer(changeCtrl.getChangeNumber());
+        changeInfo = changeCtrl.getChangeNumber();
 
         if (oldName != null) {
             oldBd = new Binding(oldName, className, /*obj=*/null, /*isRelative=*/true);


### PR DESCRIPTION
The constructors used to convert primitives into the corresponding objects were deprecated in Java 9 so they have been replaced with autoboxing.

https://bugs.openjdk.java.net/browse/JDK-8176335