### PR TITLE
Deprecate LDAPv2 class

### DIFF
--- a/docs/changes/v5.2.0/API-Changes.adoc
+++ b/docs/changes/v5.2.0/API-Changes.adoc
@@ -1,0 +1,6 @@
+= API Changes =
+
+== Deprecate LDAPv2 ==
+
+The `netscape.ldap.LDAPv2` interface has been deprecated.
+Use `netscape.ldap.LDAPConnection` instead.

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPConnection.java
@@ -2429,7 +2429,7 @@ public class LDAPConnection
      *
      * LDAPSearchResults myResults = null;
      * try {
-     *    myResults = myConn.search( myBaseDN, LDAPv2.SCOPE_SUB, myFilter, myAttrs, false );
+     *    myResults = myConn.search( myBaseDN, LDAPConnection.SCOPE_SUB, myFilter, myAttrs, false );
      * } catch ( LDAPException e ) {
      *    int errCode = e.getLDAPResultCode();
      *    System.out.println( "LDAPException: return code:" + errCode );
@@ -2462,10 +2462,10 @@ public class LDAPConnection
      * @param scope the scope of the entries to search.  You can specify one
      * of the following: <P>
      * <UL>
-     * <LI><CODE>LDAPv2.SCOPE_BASE</CODE> (search only the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_ONE</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_BASE</CODE> (search only the base DN) <P>
+     * <LI><CODE>LDAPConnection.SCOPE_ONE</CODE>
      * (search only entries under the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_SUB</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_SUB</CODE>
      * (search the base DN and all entries within its subtree) <P>
      * </UL>
      * <P>
@@ -2511,7 +2511,7 @@ public class LDAPConnection
      *
      * LDAPSearchResults myResults = null;
      * try {
-     *    myResults = myConn.search( myBaseDN, LDAPv2.SCOPE_SUB, myFilter, myAttrs, false, mySearchConstraints );
+     *    myResults = myConn.search( myBaseDN, LDAPConnection.SCOPE_SUB, myFilter, myAttrs, false, mySearchConstraints );
      * } catch ( LDAPException e ) {
      *    int errCode = e.getLDAPResultCode();
      *    System.out.println( "LDAPException: return code:" + errCode );
@@ -2526,10 +2526,10 @@ public class LDAPConnection
      * @param scope the scope of the entries to search.  You can specify one
      * of the following: <P>
      * <UL>
-     * <LI><CODE>LDAPv2.SCOPE_BASE</CODE> (search only the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_ONE</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_BASE</CODE> (search only the base DN) <P>
+     * <LI><CODE>LDAPConnection.SCOPE_ONE</CODE>
      * (search only entries under the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_SUB</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_SUB</CODE>
      * (search the base DN and all entries within its subtree) <P>
      * </UL>
      * <P>
@@ -2583,7 +2583,7 @@ public class LDAPConnection
         /* Is this a persistent search? */
         boolean isPersistentSearch = false;
         LDAPControl[] controls =
-            (LDAPControl[])getOption(LDAPv3.SERVERCONTROLS, cons);
+            (LDAPControl[])getOption(SERVERCONTROLS, cons);
         for (int i = 0; (controls != null) && (i < controls.length); i++) {
             if ( controls[i] instanceof
                  netscape.ldap.controls.LDAPPersistSearchControl ) {
@@ -3916,10 +3916,10 @@ public class LDAPConnection
      * @param scope the scope of the entries to search.  You can specify one
      * of the following: <P>
      * <UL>
-     * <LI><CODE>LDAPv2.SCOPE_BASE</CODE> (search only the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_ONE</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_BASE</CODE> (search only the base DN) <P>
+     * <LI><CODE>LDAPConnection.SCOPE_ONE</CODE>
      * (search only entries under the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_SUB</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_SUB</CODE>
      * (search the base DN and all entries within its subtree) <P>
      * </UL>
      * <P>
@@ -3959,10 +3959,10 @@ public class LDAPConnection
      * @param scope the scope of the entries to search.  You can specify one
      * of the following: <P>
      * <UL>
-     * <LI><CODE>LDAPv2.SCOPE_BASE</CODE> (search only the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_ONE</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_BASE</CODE> (search only the base DN) <P>
+     * <LI><CODE>LDAPConnection.SCOPE_ONE</CODE>
      * (search only entries under the base DN) <P>
-     * <LI><CODE>LDAPv2.SCOPE_SUB</CODE>
+     * <LI><CODE>LDAPConnection.SCOPE_SUB</CODE>
      * (search the base DN and all entries within its subtree) <P>
      * </UL>
      * <P>
@@ -4151,7 +4151,7 @@ public class LDAPConnection
      *
      * <PRE>
      * LDAPConnection ld = new LDAPConnection();
-     * int sizeLimit = ( (Integer)ld.getOption( LDAPv2.SIZELIMIT ) ).intValue();
+     * int sizeLimit = ( (Integer)ld.getOption( LDAPConnection.SIZELIMIT ) ).intValue();
      * System.out.println( "Maximum number of results: " + sizeLimit );
      * </PRE>
      *
@@ -4160,13 +4160,13 @@ public class LDAPConnection
      * <TR VALIGN=BASELINE ALIGN=LEFT>
      * <TH>Option</TH><TH>Data Type</TH><TH>Description</TH></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.PROTOCOL_VERSION</CODE></TD>
+     * <CODE>LDAPConnection.PROTOCOL_VERSION</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the version of the LDAP protocol used by the
      * client.
      * <P>By default, the value of this option is 2.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.DEREF</CODE></TD>
+     * <CODE>LDAPConnection.DEREF</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies when your client dereferences aliases.
      *<PRE>
@@ -4190,20 +4190,20 @@ public class LDAPConnection
      * <P>By default, the value of this option is
      * <CODE>DEREF_NEVER</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.SIZELIMIT</CODE></TD>
+     * <CODE>LDAPConnection.SIZELIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of search results to return.
      * If this option is set to 0, there is no maximum limit.
      * <P>By default, the value of this option is 1000.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.TIMELIMIT</CODE></TD>
+     * <CODE>LDAPConnection.TIMELIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of milliseconds to wait for results
      * before timing out. If this option is set to 0, there is no maximum
      * time limit.
      * <P>By default, the value of this option is 0.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS</CODE></TD>
      * <TD><CODE>Boolean</CODE></TD>
      * <TD>Specifies whether or not your client follows referrals automatically.
      * If <CODE>true</CODE>, your client follows referrals automatically.
@@ -4211,26 +4211,26 @@ public class LDAPConnection
      * when referral is detected.
      * <P>By default, the value of this option is <CODE>false</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS_REBIND_PROC</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS_REBIND_PROC</CODE></TD>
      * <TD><CODE>LDAPRebind</CODE></TD>
      * <TD>Specifies an object with a class that implements the
      * <CODE>LDAPRebind</CODE> interface.  You must define this class and
      * the <CODE>getRebindAuthentication</CODE> method that will be used to
      * get the distinguished name and password to use for authentication.
-     * Modifying this option sets the <CODE>LDAPv2.BIND</CODE> option to null.
+     * Modifying this option sets the <CODE>LDAPConnection.BIND</CODE> option to null.
      * <P>By default, the value of this option is <CODE>null</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.BIND</CODE></TD>
+     * <CODE>LDAPConnection.BIND</CODE></TD>
      * <TD><CODE>LDAPBind</CODE></TD>
      * <TD>Specifies an object with a class that implements the
      * <CODE>LDAPBind</CODE>
      * interface.  You must define this class and the
      * <CODE>bind</CODE> method that will be used to authenticate
      * to the server on referrals. Modifying this option sets the
-     * <CODE>LDAPv2.REFERRALS_REBIND_PROC</CODE> to null.
+     * <CODE>LDAPConnection.REFERRALS_REBIND_PROC</CODE> to null.
      * <P>By default, the value of this option is <CODE>null</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS_HOP_LIMIT</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS_HOP_LIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of referrals in a sequence that
      * your client will follow.  (For example, if REFERRALS_HOP_LIMIT is 5,
@@ -4238,7 +4238,7 @@ public class LDAPConnection
      * a single LDAP request.)
      * <P>By default, the value of this option is 10.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.BATCHSIZE</CODE></TD>
+     * <CODE>LDAPConnection.BATCHSIZE</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the number of search results to return at a time.
      * (For example, if BATCHSIZE is 1, results are returned one at a time.)
@@ -4279,7 +4279,7 @@ public class LDAPConnection
      * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean, netscape.ldap.LDAPSearchConstraints)
      */
     public Object getOption( int option ) throws LDAPException {
-        if (option == LDAPv2.PROTOCOL_VERSION) {
+        if (option == PROTOCOL_VERSION) {
             return m_protocolVersion;
         }
 
@@ -4289,25 +4289,25 @@ public class LDAPConnection
     private static Object getOption( int option, LDAPSearchConstraints cons )
         throws LDAPException {
         switch (option) {
-            case LDAPv2.DEREF:
+            case DEREF:
               return cons.getDereference();
-            case LDAPv2.SIZELIMIT:
+            case SIZELIMIT:
               return cons.getMaxResults();
-            case LDAPv2.TIMELIMIT:
+            case TIMELIMIT:
               return cons.getServerTimeLimit();
-            case LDAPv2.REFERRALS:
+            case REFERRALS:
               return cons.getReferrals();
-            case LDAPv2.REFERRALS_REBIND_PROC:
+            case REFERRALS_REBIND_PROC:
               return cons.getRebindProc();
-            case LDAPv2.BIND:
+            case BIND:
               return cons.getBindProc();
-            case LDAPv2.REFERRALS_HOP_LIMIT:
+            case REFERRALS_HOP_LIMIT:
               return cons.getHopLimit();
-            case LDAPv2.BATCHSIZE:
+            case BATCHSIZE:
               return cons.getBatchSize();
-            case LDAPv3.CLIENTCONTROLS:
+            case CLIENTCONTROLS:
               return cons.getClientControls();
-            case LDAPv3.SERVERCONTROLS:
+            case SERVERCONTROLS:
               return cons.getServerControls();
             case MAXBACKLOG:
               return cons.getMaxBacklog();
@@ -4347,7 +4347,7 @@ public class LDAPConnection
      * <PRE>
      * LDAPConnection ld = new LDAPConnection();
      * Integer newLimit = new Integer( 20 );
-     * ld.setOption( LDAPv2.SIZELIMIT, newLimit );
+     * ld.setOption( LDAPConnection.SIZELIMIT, newLimit );
      * System.out.println( "Changed the maximum number of results to " + newLimit.intValue() );
      * </PRE>
      *
@@ -4356,7 +4356,7 @@ public class LDAPConnection
      * <TR VALIGN=BASELINE ALIGN=LEFT>
      * <TH>Option</TH><TH>Data Type</TH><TH>Description</TH></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.PROTOCOL_VERSION</CODE></TD>
+     * <CODE>LDAPConnection.PROTOCOL_VERSION</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the version of the LDAP protocol used by the
      * client.
@@ -4364,7 +4364,7 @@ public class LDAPConnection
      * to use LDAP v3 features (such as extended operations or
      * controls), you need to set this value to 3. </TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.DEREF</CODE></TD>
+     * <CODE>LDAPConnection.DEREF</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies when your client dereferences aliases.
      *<PRE>
@@ -4388,20 +4388,20 @@ public class LDAPConnection
      * <P>By default, the value of this option is
      * <CODE>DEREF_NEVER</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.SIZELIMIT</CODE></TD>
+     * <CODE>LDAPConnection.SIZELIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of search results to return.
      * If this option is set to 0, there is no maximum limit.
      * <P>By default, the value of this option is 1000.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.TIMELIMIT</CODE></TD>
+     * <CODE>LDAPConnection.TIMELIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of milliseconds to wait for results
      * before timing out. If this option is set to 0, there is no maximum
      * time limit.
      * <P>By default, the value of this option is 0.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS</CODE></TD>
      * <TD><CODE>Boolean</CODE></TD>
      * <TD>Specifies whether or not your client follows referrals automatically.
      * If <CODE>true</CODE>, your client follows referrals automatically.
@@ -4409,27 +4409,27 @@ public class LDAPConnection
      * raised when a referral is detected.
      * <P>By default, the value of this option is <CODE>false</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS_REBIND_PROC</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS_REBIND_PROC</CODE></TD>
      * <TD><CODE>LDAPRebind</CODE></TD>
      * <TD>Specifies an object with a class that implements the
      * <CODE>LDAPRebind</CODE>
      * interface.  You must define this class and the
      * <CODE>getRebindAuthentication</CODE> method that will be used to get
      * the distinguished name and password to use for authentication.
-     * Modifying this option sets the <CODE>LDAPv2.BIND</CODE> option to null.
+     * Modifying this option sets the <CODE>LDAPConnection.BIND</CODE> option to null.
      * <P>By default, the value of this option is <CODE>null</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.BIND</CODE></TD>
+     * <CODE>LDAPConnection.BIND</CODE></TD>
      * <TD><CODE>LDAPBind</CODE></TD>
      * <TD>Specifies an object with a class that implements the
      * <CODE>LDAPBind</CODE>
      * interface.  You must define this class and the
      * <CODE>bind</CODE> method that will be used to autheniticate
      * to the server on referrals. Modifying this option sets the
-     * <CODE>LDAPv2.REFERRALS_REBIND_PROC</CODE> to null.
+     * <CODE>LDAPConnection.REFERRALS_REBIND_PROC</CODE> to null.
      * <P>By default, the value of this option is <CODE>null</CODE>.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.REFERRALS_HOP_LIMIT</CODE></TD>
+     * <CODE>LDAPConnection.REFERRALS_HOP_LIMIT</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the maximum number of referrals in a sequence that
      * your client will follow.  (For example, if REFERRALS_HOP_LIMIT is 5,
@@ -4437,7 +4437,7 @@ public class LDAPConnection
      * a single LDAP request.)
      * <P>By default, the value of this option is 10.</TD></TR>
      * <TR VALIGN=BASELINE><TD>
-     * <CODE>LDAPv2.BATCHSIZE</CODE></TD>
+     * <CODE>LDAPConnection.BATCHSIZE</CODE></TD>
      * <TD><CODE>Integer</CODE></TD>
      * <TD>Specifies the number of search results to return at a time.
      * (For example, if BATCHSIZE is 1, results are returned one at a time.)
@@ -4477,7 +4477,7 @@ public class LDAPConnection
      * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean, netscape.ldap.LDAPSearchConstraints)
      */
     public void setOption( int option, Object value ) throws LDAPException {
-        if (option == LDAPv2.PROTOCOL_VERSION) {
+        if (option == PROTOCOL_VERSION) {
             setProtocolVersion(((Integer)value).intValue());
             return;
         }
@@ -4487,34 +4487,34 @@ public class LDAPConnection
     private static void setOption( int option, Object value, LDAPSearchConstraints cons ) throws LDAPException {
       try {
         switch (option) {
-        case LDAPv2.DEREF:
+        case DEREF:
           cons.setDereference(((Integer)value).intValue());
           return;
-        case LDAPv2.SIZELIMIT:
+        case SIZELIMIT:
           cons.setMaxResults(((Integer)value).intValue());
           return;
-        case LDAPv2.TIMELIMIT:
+        case TIMELIMIT:
           cons.setTimeLimit(((Integer)value).intValue());
           return;
-        case LDAPv2.SERVER_TIMELIMIT:
+        case SERVER_TIMELIMIT:
           cons.setServerTimeLimit(((Integer)value).intValue());
           return;
-        case LDAPv2.REFERRALS:
+        case REFERRALS:
           cons.setReferrals(((Boolean)value).booleanValue());
           return;
-        case LDAPv2.BIND:
+        case BIND:
           cons.setBindProc((LDAPBind)value);
           return;
-        case LDAPv2.REFERRALS_REBIND_PROC:
+        case REFERRALS_REBIND_PROC:
           cons.setRebindProc((LDAPRebind)value);
           return;
-        case LDAPv2.REFERRALS_HOP_LIMIT:
+        case REFERRALS_HOP_LIMIT:
           cons.setHopLimit(((Integer)value).intValue());
           return;
-        case LDAPv2.BATCHSIZE:
+        case BATCHSIZE:
           cons.setBatchSize(((Integer)value).intValue());
           return;
-        case LDAPv3.CLIENTCONTROLS:
+        case CLIENTCONTROLS:
           if ( value == null )
             cons.setClientControls( (LDAPControl[]) null );
           else if ( value instanceof LDAPControl )
@@ -4525,7 +4525,7 @@ public class LDAPConnection
             throw new LDAPException ( "invalid LDAPControl",
                                       LDAPException.PARAM_ERROR );
           return;
-        case LDAPv3.SERVERCONTROLS:
+        case SERVERCONTROLS:
           if ( value == null )
             cons.setServerControls( (LDAPControl[]) null );
           else if ( value instanceof LDAPControl )
@@ -4698,7 +4698,7 @@ public class LDAPConnection
      * myOptions.setMaxResults( 10 );
      * String[] myAttrs = { "objectclass" };
      * LDAPSearchResults myResults = ld.search( "o=Ace Industry,c=US",
-     *                                          LDAPv2.SCOPE_SUB,
+     *                                          LDAPConnection.SCOPE_SUB,
      *                                          "(objectclass=*)",
      *                                          myAttrs,
      *                                          false,

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPControl.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPControl.java
@@ -178,8 +178,8 @@ import netscape.ldap.util.LDIF;
  * <P>
  *
  * @version 1.0
- * @see netscape.ldap.LDAPv3#CLIENTCONTROLS
- * @see netscape.ldap.LDAPv3#SERVERCONTROLS
+ * @see netscape.ldap.LDAPConnection#CLIENTCONTROLS
+ * @see netscape.ldap.LDAPConnection#SERVERCONTROLS
  * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean)
  * @see netscape.ldap.LDAPConnection#getOption
  * @see netscape.ldap.LDAPConnection#setOption

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPException.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPException.java
@@ -564,10 +564,10 @@ public class LDAPException extends java.lang.Exception
      * the client may be referred first from LDAP server A to
      * LDAP server B, then from LDAP server B to LDAP server C,
      * and so on) has exceeded the maximum number of referrals
-     * (the <CODE>LDAPv2.REFERRALS_HOP_LIMIT</CODE> option).
+     * (the <CODE>LDAPConnection.REFERRALS_HOP_LIMIT</CODE> option).
      * <P>
      *
-     * @see netscape.ldap.LDAPv2#REFERRALS_HOP_LIMIT
+     * @see netscape.ldap.LDAPConnection#REFERRALS_HOP_LIMIT
      * @see netscape.ldap.LDAPConnection#getOption
      * @see netscape.ldap.LDAPConnection#setOption
      */

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSchema.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPSchema.java
@@ -870,7 +870,7 @@ public class LDAPSchema implements java.io.Serializable {
     private static LDAPEntry readSchema( LDAPConnection ld, String dn,
                                          String[] attrs )
                                          throws LDAPException {
-        LDAPSearchResults results = ld.search (dn, LDAPv2.SCOPE_BASE,
+        LDAPSearchResults results = ld.search (dn, LDAPConnection.SCOPE_BASE,
                                                "objectclass=subschema",
                                                attrs, false);
         if ( !results.hasMoreElements() ) {

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPUrl.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPUrl.java
@@ -125,7 +125,7 @@ public class LDAPUrl implements java.io.Serializable {
      */
     public LDAPUrl (String url) throws java.net.MalformedURLException {
         m_attributes = null;
-        m_scope = LDAPv2.SCOPE_BASE;
+        m_scope = LDAPConnection.SCOPE_BASE;
         m_filter = defaultFilter;
         m_URL = url;
 
@@ -176,7 +176,7 @@ public class LDAPUrl implements java.io.Serializable {
         // host-port
         if (currentToken.equals ("/")) {
             m_hostName = null;
-            m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPv2.DEFAULT_PORT;
+            m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPConnection.DEFAULT_PORT;
             usingDefaultHostPort = true;
         } else if (currentToken.equals (":")) {
                 // port number without host name is not allowed
@@ -200,7 +200,7 @@ public class LDAPUrl implements java.io.Serializable {
         if (usingDefaultHostPort == false) {
             // Set the port
             if (urlParser.countTokens() == 0) {
-                m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPv2.DEFAULT_PORT;
+                m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPConnection.DEFAULT_PORT;
                 return;
             }
 
@@ -222,7 +222,7 @@ public class LDAPUrl implements java.io.Serializable {
                     throw new MalformedURLException ();
                 }
             } else if (currentToken.equals ("/")) {
-                m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPv2.DEFAULT_PORT;
+                m_portNumber = m_secure ? DEFAULT_SECURE_PORT : LDAPConnection.DEFAULT_PORT;
             } else {
                 // expecting ":" or "/"
                 throw new MalformedURLException ();
@@ -314,7 +314,7 @@ public class LDAPUrl implements java.io.Serializable {
      * @param DN distinguished name of the object
      */
     public LDAPUrl (String host, int port, String DN) {
-        initialize(host, port, DN, null, LDAPv2.SCOPE_BASE, defaultFilter, false);
+        initialize(host, port, DN, null, LDAPConnection.SCOPE_BASE, defaultFilter, false);
     }
 
     /**
@@ -440,11 +440,11 @@ public class LDAPUrl implements java.io.Serializable {
 
             switch (scope) {
               default:
-              case LDAPv2.SCOPE_BASE:
+              case LDAPConnection.SCOPE_BASE:
                 url.append ("base"); break;
-              case LDAPv2.SCOPE_ONE:
+              case LDAPConnection.SCOPE_ONE:
                 url.append ("one"); break;
-              case LDAPv2.SCOPE_SUB:
+              case LDAPConnection.SCOPE_SUB:
                 url.append ("sub"); break;
             }
 
@@ -541,11 +541,11 @@ public class LDAPUrl implements java.io.Serializable {
 
         int s = -1;
         if (str.equalsIgnoreCase("base"))
-            s = LDAPv2.SCOPE_BASE;
+            s = LDAPConnection.SCOPE_BASE;
         else if (str.equalsIgnoreCase("one"))
-            s = LDAPv2.SCOPE_ONE;
+            s = LDAPConnection.SCOPE_ONE;
         else if (str.equalsIgnoreCase("sub"))
-            s = LDAPv2.SCOPE_SUB;
+            s = LDAPConnection.SCOPE_SUB;
 
         return s;
     }

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPv2.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPv2.java
@@ -58,7 +58,9 @@ package netscape.ldap;
  * sequence (Strings or binary values).
  *
  * @version 1.0
+ * @deprecated Use netscape.ldap.LDAPConnection instead.
  */
+@Deprecated(since = "5.2.0", forRemoval = true)
 public interface LDAPv2 {
     /**
      * The default port number for LDAP servers.  You can specify

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPv3.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPv3.java
@@ -43,7 +43,185 @@ package netscape.ldap;
  *
  * @version 1.0
  */
+@SuppressWarnings("removal")
 public interface LDAPv3 extends LDAPv2 {
+
+    /**
+     * The default port number for LDAP servers.  You can specify
+     * this identifier when calling the <CODE>LDAPConnection.connect</CODE>
+     * method to connect to an LDAP server.
+     * @see netscape.ldap.LDAPConnection#connect
+     */
+    public final static int DEFAULT_PORT = 389;
+
+    /**
+     * Option specifying how aliases are dereferenced.
+     * <P>
+     *
+     * This option can have one of the following values:
+     * <UL>
+     * <LI><A HREF="#DEREF_NEVER"><CODE>DEREF_NEVER</CODE></A>
+     * <LI><A HREF="#DEREF_FINDING"><CODE>DEREF_FINDING</CODE></A>
+     * <LI><A HREF="#DEREF_SEARCHING"><CODE>DEREF_SEARCHING</CODE></A>
+     * <LI><A HREF="#DEREF_ALWAYS"><CODE>DEREF_ALWAYS</CODE></A>
+     * </UL>
+     * <P>
+     *
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int DEREF = 2;
+
+    /**
+     * Option specifying the maximum number of search results to
+     * return.
+     * <P>
+     *
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int SIZELIMIT = 3;
+
+    /**
+     * Option specifying the maximum number of milliseconds to
+     * wait for an operation to complete.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int TIMELIMIT = 4;
+
+    /**
+     * Option specifying the maximum number of milliseconds the
+     * server should spend returning search results before aborting
+     * the search.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int SERVER_TIMELIMIT = 5;
+
+    /**
+     * Option specifying whether or not referrals to other LDAP
+     * servers are followed automatically.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     * @see netscape.ldap.LDAPRebind
+     * @see netscape.ldap.LDAPRebindAuth
+     */
+    public static final int REFERRALS = 8;
+
+    /**
+     * Option specifying the object containing the method for
+     * getting authentication information (the distinguished name
+     * and password) used during a referral.  For example, when
+     * referred to another LDAP server, your client uses this object
+     * to obtain the DN and password.  Your client authenticates to
+     * the LDAP server using this DN and password.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     * @see netscape.ldap.LDAPRebind
+     * @see netscape.ldap.LDAPRebindAuth
+     */
+    public static final int REFERRALS_REBIND_PROC = 9;
+
+    /**
+     * Option specifying the maximum number of referrals to follow
+     * in a sequence when requesting an LDAP operation.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int REFERRALS_HOP_LIMIT   = 10;
+
+    /**
+     * Option specifying the object containing the method for
+     * authenticating to the server.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     * @see netscape.ldap.LDAPBind
+     */
+    public static final int BIND = 13;
+
+    /**
+     * Option specifying the version of the LDAP protocol
+     * used by your client when interacting with the LDAP server.
+     * If no version is set, the default version is 2.  If you
+     * are planning to use LDAP v3 features (such as controls
+     * or extended operations), you should set this version to 3
+     * or specify version 3 as an argument to the <CODE>authenticate</CODE>
+     * method of the <CODE>LDAPConnection</CODE> object.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     * @see netscape.ldap.LDAPConnection#authenticate(int, java.lang.String, java.lang.String)
+     */
+    public static final int PROTOCOL_VERSION = 17;
+
+    /**
+     * Option specifying the number of results to return at a time.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int BATCHSIZE = 20;
+
+
+    /*
+     * Valid options for Scope
+     */
+
+    /**
+     * Specifies that the scope of a search includes
+     * only the base DN (distinguished name).
+     * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean, netscape.ldap.LDAPSearchConstraints)
+     */
+    public static final int SCOPE_BASE = 0;
+
+    /**
+     * Specifies that the scope of a search includes
+     * only the entries one level below the base DN (distinguished name).
+     * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean, netscape.ldap.LDAPSearchConstraints)   */
+    public static final int SCOPE_ONE = 1;
+
+    /**
+     * Specifies that the scope of a search includes
+     * the base DN (distinguished name) and all entries at all levels
+     * beneath that base.
+     * @see netscape.ldap.LDAPConnection#search(java.lang.String, int, java.lang.String, java.lang.String[], boolean, netscape.ldap.LDAPSearchConstraints)   */
+    public static final int SCOPE_SUB = 2;
+
+
+    /*
+     * Valid options for Dereference
+     */
+
+    /**
+     * Specifies that aliases are never dereferenced.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int DEREF_NEVER = 0;
+
+    /**
+     * Specifies that aliases are dereferenced when searching the
+     * entries beneath the starting point of the search (but
+     * not when finding the starting entry).
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int DEREF_SEARCHING = 1;
+
+    /**
+     * Specifies that aliases are dereferenced when finding the
+     * starting point for the search (but not when searching
+     * under that starting entry).
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int DEREF_FINDING = 2;
+
+    /**
+     * Specifies that aliases are always dereferenced.
+     * @see netscape.ldap.LDAPConnection#getOption
+     * @see netscape.ldap.LDAPConnection#setOption
+     */
+    public static final int DEREF_ALWAYS = 3;
 
     /**
      * Connects and authenticates to the LDAP server using the specified version of the

--- a/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/ContextEnv.java
+++ b/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/ContextEnv.java
@@ -54,7 +54,6 @@ import netscape.ldap.LDAPRebind;
 import netscape.ldap.LDAPRebindAuth;
 import netscape.ldap.LDAPSearchConstraints;
 import netscape.ldap.LDAPUrl;
-import netscape.ldap.LDAPv2;
 
 /**
  * Context Environment
@@ -62,7 +61,7 @@ import netscape.ldap.LDAPv2;
 class ContextEnv extends ShareableEnv  {
 
     public static final String DEFAULT_HOST = "localhost";
-    public static final int    DEFAULT_PORT = LDAPv2.DEFAULT_PORT;
+    public static final int    DEFAULT_PORT = LDAPConnection.DEFAULT_PORT;
     public static final int    DEFAULT_SSL_PORT = 636;
     public static final int    DEFAULT_LDAP_VERSION = 3;
 
@@ -285,16 +284,16 @@ class ContextEnv extends ShareableEnv  {
         String deref = (String)getProperty(P_DEREF_ALIASES);
         if(deref != null) {
             if(deref.equalsIgnoreCase(V_DEREF_NEVER)) {
-                cons.setDereference(LDAPv2.DEREF_NEVER);
+                cons.setDereference(LDAPConnection.DEREF_NEVER);
             }
             else if(deref.equalsIgnoreCase(V_DEREF_SEARCHING)) {
-                        cons.setDereference(LDAPv2.DEREF_SEARCHING);
+                        cons.setDereference(LDAPConnection.DEREF_SEARCHING);
                     }
             else if(deref.equalsIgnoreCase(V_DEREF_FINDING)) {
-                cons.setDereference(LDAPv2.DEREF_FINDING);
+                cons.setDereference(LDAPConnection.DEREF_FINDING);
             }
             else if(deref.equalsIgnoreCase(V_DEREF_ALWAYS)) {
-                cons.setDereference(LDAPv2.DEREF_ALWAYS);
+                cons.setDereference(LDAPConnection.DEREF_ALWAYS);
             }
             else {
                 throw new IllegalArgumentException("Illegal value for " + P_DEREF_ALIASES);

--- a/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/LdapService.java
+++ b/java-sdk/ldapsp/src/main/java/com/netscape/jndi/ldap/LdapService.java
@@ -61,8 +61,6 @@ import netscape.ldap.LDAPSSLSocketFactory;
 import netscape.ldap.LDAPSearchConstraints;
 import netscape.ldap.LDAPSearchResults;
 import netscape.ldap.LDAPUrl;
-import netscape.ldap.LDAPv2;
-import netscape.ldap.LDAPv3;
 
 /**
  * Ldap Service encapsulates a Ldap connection and Ldap operations over the
@@ -80,9 +78,9 @@ import netscape.ldap.LDAPv3;
 class LdapService {
 
     public static final String DEFAULT_FILTER = "(objectclass=*)";
-    public static final int    DEFAULT_SCOPE = LDAPv3.SCOPE_SUB;
+    public static final int    DEFAULT_SCOPE = LDAPConnection.SCOPE_SUB;
     public static final String DEFAULT_HOST = "localhost";
-    public static final int    DEFAULT_PORT = LDAPv2.DEFAULT_PORT;
+    public static final int    DEFAULT_PORT = LDAPConnection.DEFAULT_PORT;
     public static final int    DEFAULT_SSL_PORT = 636;
 
     private LDAPConnection m_ld;
@@ -166,7 +164,7 @@ class LdapService {
 
         try {
             if (ldCtrls != null) {
-                m_ld.setOption(LDAPv3.SERVERCONTROLS, ldCtrls);
+                m_ld.setOption(LDAPConnection.SERVERCONTROLS, ldCtrls);
             }
 
             if (saslMechanisms != null) { // sasl Auth


### PR DESCRIPTION
The LDAPv2 protocol was deprecated in RFC 3494 so the `LDAPv2` interface has been deprecated.
    
To avoid deprecation warnings, all constants defined in `LDAPv2` have been copied into `LDAPv3`. All direct references to `LDAPv2` and `LDAPv3` have been replaced with `LDAPConnection` as well.

https://github.com/edewata/ldap-sdk/blob/deprecation/docs/changes/v5.2.0/API-Changes.adoc