### PR TITLE
Fix missing LDAP error messages

### DIFF
--- a/java-sdk/ietfldap/org/ietf/ldap/LDAPResourceBundle.java
+++ b/java-sdk/ietfldap/org/ietf/ldap/LDAPResourceBundle.java
@@ -125,7 +125,7 @@ class LDAPResourceBundle implements java.io.Serializable {
      */
     private static InputStream getStream( String baseName, String locale ) {
         String fStr = baseName + locale + _suffix;
-        return ClassLoader.getSystemResourceAsStream( fStr );
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(fStr);
     }
 
     /**

--- a/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPResourceBundle.java
+++ b/java-sdk/ldapjdk/src/main/java/netscape/ldap/LDAPResourceBundle.java
@@ -124,7 +124,7 @@ class LDAPResourceBundle implements java.io.Serializable {
      */
     private static InputStream getStream(String baseName, String locale) {
         String fStr = baseName+locale+m_suffix;
-        return (ClassLoader.getSystemResourceAsStream(fStr));
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(fStr);
     }
 
     /**


### PR DESCRIPTION
LDAP error messages are defined in [ErrorCodes.props](https://github.com/dogtagpki/ldap-sdk/blob/master/java-sdk/ldapjdk/src/main/resources/netscape/ldap/errors/ErrorCodes.props) which is included in `ldapjdk.jar`. Previously the file was loaded by `LDAPResourceBundle.getStream()` using the system class loader. In PKI the `ldapjdk.jar` is installed in Tomcat's common library which is not available to the system class loader so the LDAP error messages are missing. To fix the problem the code has been modified to load the file using the current class loader.

Note: The `org.ietf.ldap.*` classes are not actually used, but they are still included and maintained for historical reasons. In the future they probably can be deprecated or dropped.

See also:

* https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html
* https://stackoverflow.com/questions/2653322/getresourceasstream-not-loading-resource-in-webapp

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2084512