### PR TITLE
Workaround for DS issue

### DIFF
--- a/.github/workflows/ds-tests.yml
+++ b/.github/workflows/ds-tests.yml
@@ -81,7 +81,9 @@ jobs:
           tests/bin/runner-init.sh
 
       - name: Install DS package
-        run: docker exec ds dnf install -y 389-ds-base
+        # TODO: Remove nss-tools once the DS bug is fixed:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2110630
+        run: docker exec ds dnf install -y 389-ds-base nss-tools
 
       - name: Create DS instance
         run: docker exec ds ${SHARED}/tests/bin/ds-create.sh

--- a/tests/bin/ds-create.sh
+++ b/tests/bin/ds-create.sh
@@ -11,7 +11,7 @@ sed -i \
     -e "s/;self_sign_cert = .*/self_sign_cert = False/g" \
     ds.inf
 
-dscreate from-file ds.inf
+dscreate -v from-file ds.inf
 
 ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 << EOF
 dn: dc=example,dc=com


### PR DESCRIPTION
DS is currently missing `nss-tools` dependency so creating DS instance will fail:
https://bugzilla.redhat.com/show_bug.cgi?id=2110630

As a temporary workaround the DS test has been updated to install `nss-tools` explicitly. Once the issue is fixed the workaround should be removed.