### PR TITLE
Resolve shellcheck warnings

### DIFF
--- a/c-sdk/build_mozldap_rpm
+++ b/c-sdk/build_mozldap_rpm
@@ -50,26 +50,26 @@
 # Always switch into the base directory of this
 # shell script prior to executing it so that all
 # of its output is written to this directory
-cd `dirname $0`
+cd "$(dirname "$0")" || exit
 
 # This script may ONLY be run on Linux!
-OS=`uname`
-if [ ${OS} != "Linux" ]; then
-	echo "The '$0' script is ONLY executable on a 'Linux' machine!"
-	exit 255
+OS=$(uname)
+if [ "${OS}" != "Linux" ]; then
+    echo "The '$0' script is ONLY executable on a 'Linux' machine!"
+    exit 255
 fi
 
 # This script may ONLY be executed on either
 # an 'i386' platform or an 'x86_64' platform!
-PLATFORM=`uname -i`
-if [ ${PLATFORM} = "i386" ]; then
-	BITSIZE=32-bit
-elif [ ${PLATFORM} = "x86_64" ]; then
-	BITSIZE=64-bit
+PLATFORM=$(uname -i)
+if [ "${PLATFORM}" = "i386" ]; then
+    BITSIZE=32-bit
+elif [ "${PLATFORM}" = "x86_64" ]; then
+    BITSIZE=64-bit
 else
-	echo "The '$0' script is ONLY executable on either"
-	echo "an 'i386' platform or an 'x86_64' platform!"
-	exit 255
+    echo "The '$0' script is ONLY executable on either"
+    echo "an 'i386' platform or an 'x86_64' platform!"
+    exit 255
 fi
 
 # initialize environment variables for this script
@@ -84,60 +84,60 @@ VERSION=6.0.0
 RELEASE=1
 MOZLDAP_TAG=LDAPCSDK_6_0_0_RTM
 PRJ=${PACKAGE}-${VERSION}
-RPM_HOME=`pwd`
+RPM_HOME=$(pwd)
 SPEC_FILENAME=${PACKAGE}.spec
 
 # define subroutines for this script
 usage() {
-	echo
-	echo "Usage:  $0"
-	echo
+    echo
+    echo "Usage:  $0"
+    echo
 }
 
 mkdirs() {
-	for d in "$@" ; do
-		if [ -d $d ]; then
-			mv $d $d.deleted
-			rm -rf $d.deleted &
-		fi
-		mkdir -p $d
-	done
+    for d in "$@" ; do
+        if [ -d "$d" ]; then
+            mv "$d" "$d".deleted
+            rm -rf "$d".deleted &
+        fi
+        mkdir -p "$d"
+    done
 }
 
 # check the number of arguments supplied to this script
 if [ $# -ne 0 ] ; then
-	usage
-	exit 255
+    usage
+    exit 255
 fi
 
 # remove any old RPM directories
 echo "Removing any old RPM directories . . ."
-if [ -d ${RPM_HOME}/BUILD ]; then
-	rm -rf ${RPM_HOME}/BUILD
+if [ -d "${RPM_HOME}"/BUILD ]; then
+    rm -rf "${RPM_HOME}"/BUILD
 fi
-if [ -d ${RPM_HOME}/SOURCES ]; then
-	rm -rf ${RPM_HOME}/SOURCES
+if [ -d "${RPM_HOME}"/SOURCES ]; then
+    rm -rf "${RPM_HOME}"/SOURCES
 fi
-if [ -d ${RPM_HOME}/SPECS ]; then
-	rm -rf ${RPM_HOME}/SPECS
+if [ -d "${RPM_HOME}"/SPECS ]; then
+    rm -rf "${RPM_HOME}"/SPECS
 fi
 echo "Finished."
 
 echo "Changing current working directory to ${RPM_HOME}."
-cd ${RPM_HOME}
+cd "${RPM_HOME}" || exit
 
 # create new RPM directories
 echo "Creating new RPM directories . . ."
 mkdirs BUILD
-if [ ! -d ${RPM_HOME}/RPMS ]; then
-	mkdirs ${RPM_HOME}/RPMS
+if [ ! -d "${RPM_HOME}"/RPMS ]; then
+    mkdirs "${RPM_HOME}"/RPMS
 fi
-if [ ! -d ${RPM_HOME}/SGTARS ]; then
-	mkdirs ${RPM_HOME}/SGTARS
+if [ ! -d "${RPM_HOME}"/SGTARS ]; then
+    mkdirs "${RPM_HOME}"/SGTARS
 fi
 mkdirs SOURCES SPECS
-if [ ! -d ${RPM_HOME}/SRPMS ]; then
-	mkdirs ${RPM_HOME}/SRPMS
+if [ ! -d "${RPM_HOME}"/SRPMS ]; then
+    mkdirs "${RPM_HOME}"/SRPMS
 fi
 echo "Finished."
 
@@ -162,27 +162,27 @@ cp mozldap.spec SPECS/${SPEC_FILENAME}
 # build the ${BITSIZE} RPM and Source RPM
 echo "Executing ${BITSIZE} rpmbuild of ${SPEC_FILENAME} file . . . "
 if [ ! -f SRPMS/${PACKAGE}-${VERSION}-${RELEASE}.src.rpm ]; then
-	rpmbuild --define="_topdir ${RPM_HOME}" --target ${PLATFORM} -ba --clean --rmsource --rmspec SPECS/${SPEC_FILENAME}
+    rpmbuild --define="_topdir ${RPM_HOME}" --target "${PLATFORM}" -ba --clean --rmsource --rmspec SPECS/${SPEC_FILENAME}
 else
-	rpmbuild --define="_topdir ${RPM_HOME}" --target ${PLATFORM} -bb --clean --rmsource --rmspec SPECS/${SPEC_FILENAME}
+    rpmbuild --define="_topdir ${RPM_HOME}" --target "${PLATFORM}" -bb --clean --rmsource --rmspec SPECS/${SPEC_FILENAME}
 fi
 echo "Finished doing ${BITSIZE} rpmbuild of ${SPEC_FILENAME} file."
 
 echo "Removing BUILD directory . . ."
-if [ -d ${RPM_HOME}/BUILD ]; then
-	rm -rf ${RPM_HOME}/BUILD
+if [ -d "${RPM_HOME}"/BUILD ]; then
+    rm -rf "${RPM_HOME}"/BUILD
 fi
 echo "Finished."
 
 echo "Removing SOURCES directory . . ."
-if [ -d ${RPM_HOME}/SOURCES ]; then
-	rm -rf ${RPM_HOME}/SOURCES
+if [ -d "${RPM_HOME}"/SOURCES ]; then
+    rm -rf "${RPM_HOME}"/SOURCES
 fi
 echo "Finished."
 
 echo "Removing SPECS directory . . ."
-if [ -d ${RPM_HOME}/SPECS ]; then
-	rm -rf ${RPM_HOME}/SPECS
+if [ -d "${RPM_HOME}"/SPECS ]; then
+    rm -rf "${RPM_HOME}"/SPECS
 fi
 echo "Finished."
 

--- a/c-sdk/config/cygwin-wrapper
+++ b/c-sdk/config/cygwin-wrapper
@@ -6,6 +6,9 @@
 # and look at the older versions of this file that are easier to read, but
 # do basically the same thing
 #
+# There are /sh compatibility issues that require changing shell to fix
+# Disable these checks as altering shell could have unintended consequences 
+# shellcheck disable=SC3000-SC4000
 
 prog=$1
 shift
@@ -16,7 +19,7 @@ fi
 # If $CYGDRIVE_MOUNT was not set in configure, give $mountpoint the results of mount -p
 mountpoint=$CYGDRIVE_MOUNT
 if test -z "$mountpoint"; then
-    mountpoint=`mount -p`
+    mountpoint=$(mount -p)
     if test -z "$mountpoint"; then
        print "Cannot determine cygwin mount points. Exiting"
        exit 1
@@ -56,24 +59,24 @@ do
                         driveletter=${no_i%%:*}
                         i=-I${mountpoint}/${driveletter}/${pathname}
                     elif test "${pathname:0:1}" = "/" -a -e "${pathname}" ; then
-			i=-I`cygpath -m "${pathname}"`
+            i=-I$(cygpath -m "${pathname}")
                     fi
                 else
-                    eval 'leader=${i%%'${mountpoint}'/[a-zA-Z]/*}'
+                    leader=$(eval '${i%%'"${mountpoint}"'/[a-zA-Z]/*}')
                     if ! test "${leader}" = "${i}"; then
-                        eval 'pathname=${i#'${leader}${mountpoint}'/[a-zA-Z]/}'
-                        eval 'no_mountpoint=${i#'${leader}${mountpoint}'/}'
+                        pathname=$(eval '${i#'"${leader}""${mountpoint}"'/[a-zA-Z]/}')
+                        no_mountpoint=$(eval '${i#'"${leader}""${mountpoint}"'/}')
                         driveletter=${no_mountpoint%%/*}
                         i=${leader}${driveletter}:/${pathname}
                     elif test "${i:0:1}" = "/" -a -e "${i}" ; then
-			i=`cygpath -m "${i}"`
-		    elif test "${i:0:2}" = "-I" -a -e "${i:2}" ; then
-			i=/I`cygpath -m "${i:2}"`
-		    elif test "${i:0:2}" = "-L" -a -e "${i:2}" ; then
-			i=/L`cygpath -m "${i:2}"`
-		    elif test "${i:0:5}" = "-DEF:" -a -e "${i:5}" ; then
-			i=/DEF:`cygpath -m "${i:5}"`
-		    fi
+            i=$(cygpath -m "${i}")
+            elif test "${i:0:2}" = "-I" -a -e "${i:2}" ; then
+            i=/I$(cygpath -m "${i:2}")
+            elif test "${i:0:2}" = "-L" -a -e "${i:2}" ; then
+            i=/L$(cygpath -m "${i:2}")
+            elif test "${i:0:5}" = "-DEF:" -a -e "${i:5}" ; then
+            i=/DEF:$(cygpath -m "${i:5}")
+            fi
                 fi
             fi
 
@@ -82,4 +85,4 @@ do
     fi
 done
 
-exec $prog $args
+exec $prog "$args"

--- a/c-sdk/ldap/build/compver.sh
+++ b/c-sdk/ldap/build/compver.sh
@@ -47,18 +47,20 @@ COMP_ROOT=$1
 COMP_VERSION=$2
 COMP_VERSION_FILE=${COMP_ROOT}/Version
 COMPOBJDIR=$3
+# Unused, but leave as changing args could break other tools
+# shellcheck disable=SC2034
 MCOM_ROOT=$4
-MODULE=$5		# Module which needs this component
-COMP_RELEASE=$6		# Component release dir
-COMP_NAME=$7		# component name (e.g. ldapsdk, rouge)
-COMP_SUBDIRS=$8		# subdirs to ftp over
-TEST_FILE=$9		# to test if ftp was successful
+MODULE=$5       # Module which needs this component
+COMP_RELEASE=$6     # Component release dir
+COMP_NAME=$7        # component name (e.g. ldapsdk, rouge)
+COMP_SUBDIRS=$8     # subdirs to ftp over
+TEST_FILE=$9        # to test if ftp was successful
 
-if test -r ${COMP_VERSION_FILE}; then \
-  CUR_VERSION=`cat ${COMP_VERSION_FILE}`; \
+if test -r "${COMP_VERSION_FILE}"; then \
+  CUR_VERSION=$(cat "${COMP_VERSION_FILE}"); \
 
   if test "${CUR_VERSION}" = "${COMP_VERSION}"; then \
-    if test -d ${COMP_ROOT}/${COMPOBJDIR}; then \
+    if test -d "${COMP_ROOT}"/"${COMPOBJDIR}"; then \
       exit 0; \
     fi; \
   fi; \
@@ -70,18 +72,18 @@ echo "The ${COMP_NAME} client libraries are missing.  "
 echo ""
 echo "Attempting to download..."
 
-rm -rf ${COMP_ROOT}/${COMPOBJDIR} ${COMP_VERSION_FILE}
-mkdir -p ${COMP_ROOT}/${COMPOBJDIR}
+rm -rf "${COMP_ROOT:?}"/"${COMPOBJDIR}" "${COMP_VERSION_FILE}"
+mkdir -p "${COMP_ROOT}"/"${COMPOBJDIR}"
 
-sh ../../build/nsftp.sh ${COMP_NAME}/${COMP_VERSION}/${COMPOBJDIR} ${COMP_ROOT}/${COMPOBJDIR}
+sh ../../build/nsftp.sh "${COMP_NAME}"/"${COMP_VERSION}"/"${COMPOBJDIR}" "${COMP_ROOT}"/"${COMPOBJDIR}"
 
 for d in ${COMP_SUBDIRS}; do \
-  mkdir -p ${COMP_ROOT}/${COMPOBJDIR}/${d}; \
-  sh ../../build/nsftp.sh ${COMP_NAME}/${COMP_VERSION}/${COMPOBJDIR}/${d} ${COMP_ROOT}/${COMPOBJDIR}/${d}
+  mkdir -p "${COMP_ROOT}"/"${COMPOBJDIR}"/"${d}"; \
+  sh ../../build/nsftp.sh "${COMP_NAME}"/"${COMP_VERSION}"/"${COMPOBJDIR}"/"${d}" "${COMP_ROOT}"/"${COMPOBJDIR}"/"${d}"
 done
 
-if test -f ${TEST_FILE}; then \
-    echo "${COMP_VERSION}" > ${COMP_VERSION_FILE}; \
+if test -f "${TEST_FILE}"; then \
+    echo "${COMP_VERSION}" > "${COMP_VERSION_FILE}"; \
     echo "************************ SUCCESS! ************************"; \
 else \
     echo ""; \

--- a/c-sdk/ldap/build/nsftp.sh
+++ b/c-sdk/ldap/build/nsftp.sh
@@ -51,20 +51,21 @@
 SERVER=$COMPONENT_FTP_SERVER
 USER=ftpman
 PASSWD=ftpman
-TMPFILE=tmp.foo
 
 SRC=$1
 DEST=$2
-if [ -z "$3" ]; then 
+if [ -z "$3" ]; then
+  # Fixing this requires changing shell as arrays are not supported with /sh
+  # shellcheck disable=SC2125
   FILENAME=*
 else
   FILENAME=$3
 fi
 
-echo ${USER} contents of ${SRC} to ${DEST}
+echo ${USER} contents of "${SRC}" to "${DEST}"
 
-cd ${DEST}
-ftp -n ${SERVER} << -=EOF=-
+cd "${DEST}" || exit
+ftp -n "${SERVER}" << -=EOF=-
 user ${USER} ${PASSWD}
 binary
 hash
@@ -73,4 +74,3 @@ cd ${SRC}
 mget ${FILENAME}
 quit
 -=EOF=-
-

--- a/tools/cvs-tools/cvscleanlog
+++ b/tools/cvs-tools/cvscleanlog
@@ -45,8 +45,8 @@
 REP_PREFIX1=/cvsroot/
 REP_PREFIX2=/anothercvsroot/
 
-GREP=grep
-SED=sed
+GREP="grep"
+SED="sed"
 
 $GREP -v '^Checking in' | grep -v '^done$' | grep -v '^Removing ' | \
 	grep -v '^cvs commit: Examining ' | \

--- a/tools/cvs-tools/cvsco
+++ b/tools/cvs-tools/cvsco
@@ -25,7 +25,7 @@
 # the Initial Developer. All Rights Reserved.
 # 
 # Contributor(s):
-#	Mark Smith <MarkCSmithWork@aol.com>
+#   Mark Smith <MarkCSmithWork@aol.com>
 # 
 # Alternatively, the contents of this file may be used under the terms of
 # either of the GNU General Public License Version 2 or later (the "GPL"),
@@ -59,56 +59,56 @@ GET_EMPTY_DIRS=0
 
 if [ $# -gt 0 ]; then
     if [ "$1" = "-H" ]; then
-	echo "usage: $0 [-dry] [-d] [cvsco-flags]";
-	exit 1;
+    echo "usage: $0 [-dry] [-d] [cvsco-flags]";
+    exit 1;
     fi
 
     if [ "$1" = "-dry" ]; then
-	shift;
-	DRYRUN=1;
+    shift;
+    DRYRUN=1;
     fi
 
     if [ "$1" = "-d" ]; then
-	shift;
-	GET_EMPTY_DIRS=1;
+    shift;
+    GET_EMPTY_DIRS=1;
     fi
 
-	
+    
 fi
 
-if [ ! -r $BRANCH_FILENAME -o ! -s $BRANCH_FILENAME ]; then
+if [ ! -r $BRANCH_FILENAME ] || [ ! -s $BRANCH_FILENAME ]; then
     echo "Please put the branch name in $BRANCH_FILENAME and try again."
     echo "Use the name -TRUNK- to pull from the trunk (no branch)."
     exit 1
 fi
 
-BRANCH=`cat $BRANCH_FILENAME`
+BRANCH=$(cat $BRANCH_FILENAME)
 if [ "$BRANCH" = "-TRUNK-" ]; then
     if [ $GET_EMPTY_DIRS -eq 0 ]; then
-	BRANCH_ARGS="-P"
+    BRANCH_ARGS="-P"
     fi
 else
     BRANCH_ARGS="-r $BRANCH"
 fi
 
-if [ -r $DATE_FILENAME -a -s $DATE_FILENAME ]; then
-    DATE=`cat $DATE_FILENAME`
+if [ -r $DATE_FILENAME ] && [ -s $DATE_FILENAME ]; then
+    DATE=$(cat $DATE_FILENAME)
     BRANCH_ARGS="$BRANCH_ARGS -D $DATE"
 fi
 
-if [ ! -r $MODULE_FILENAME -o ! -s $MODULE_FILENAME ]; then
+if [ ! -r $MODULE_FILENAME ] || [ ! -s $MODULE_FILENAME ]; then
     echo "Please put the module name in $MODULE_FILENAME and try again."
     exit 1
 fi
 
-if [ -r $REPOSITORY_FILENAME -a -s $REPOSITORY_FILENAME ]; then
-    CVSROOT=`cat $REPOSITORY_FILENAME`
+if [ -r $REPOSITORY_FILENAME ] && [ -s $REPOSITORY_FILENAME ]; then
+    CVSROOT=$(cat $REPOSITORY_FILENAME)
     export CVSROOT
     echo "Repository (CVSROOT): $CVSROOT"
 fi
 
 
-echo cvs $EXTRAOPTS co $* $BRANCH_ARGS `cat $MODULE_FILENAME`
+echo cvs $EXTRAOPTS co "$*" "$BRANCH_ARGS" "$(cat $MODULE_FILENAME)"
 if [ $DRYRUN -eq 0 ]; then
-    cvs $EXTRAOPTS co $* $BRANCH_ARGS `cat $MODULE_FILENAME`
+    cvs $EXTRAOPTS co "$*" "$BRANCH_ARGS" "$(cat $MODULE_FILENAME)"
 fi

--- a/tools/cvs-tools/cvsdl
+++ b/tools/cvs-tools/cvsdl
@@ -25,7 +25,7 @@
 # the Initial Developer. All Rights Reserved.
 # 
 # Contributor(s):
-#	Mark Smith <MarkCSmithWork@aol.com>
+#   Mark Smith <MarkCSmithWork@aol.com>
 # 
 # Alternatively, the contents of this file may be used under the terms of
 # either of the GNU General Public License Version 2 or later (the "GPL"),
@@ -43,7 +43,7 @@
 
 #
 # cvsdl: perform a 'cvs diff' to examine the last change made to a file on the
-#	current branch.
+#   current branch.
 #
 # usage: cvsdl [-n] [-v] [-revs] [cvs-diff-options] [files...]
 #   where:
@@ -68,28 +68,30 @@ EXECUTE=1
 VERBOSE=0
 
 while [ $# -ne 0 ]; do
-    if [ `expr $1 : '\(.\)'` != "-" ]; then
-	break;
+    if [ "$(expr "$1" : '\(.\)')" != "-" ]; then
+    break;
     fi
-    OPTION=`echo $1 | sed -e 's/^-//'`
-    echo $OPTION | grep '^[0-9]*$' > /dev/null 2>&1
+    OPTION=$(echo "$1" | sed -e 's/^-//')
+    echo "$OPTION" | grep '^[0-9]*$' > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-	REVSBACK=$OPTION
-    elif [ $OPTION = "n" ]; then
-	EXECUTE=0
-    elif [ $OPTION = "v" ]; then
-	VERBOSE=1
+    REVSBACK=$OPTION
+    elif [ "$OPTION" = "n" ]; then
+    EXECUTE=0
+    elif [ "$OPTION" = "v" ]; then
+    VERBOSE=1
     else
-	if [ -z "$DIFFOPTIONS" ]; then
-	    DIFFOPTIONS=$1
-	else
-	    DIFFOPTIONS="$DIFFOPTIONS "$1
-	fi
+    if [ -z "$DIFFOPTIONS" ]; then
+        DIFFOPTIONS=$1
+    else
+        DIFFOPTIONS="$DIFFOPTIONS "$1
+    fi
     fi
     shift;
 done
 
 if [ $# -eq 0 ]; then
+    # Fixing this requires changing shell as arrays are not supported with /sh
+    # shellcheck disable=SC2125
     FILES=*
 else
     FILES=$*
@@ -97,48 +99,48 @@ fi
 
 
 if [ $VERBOSE -ne 0 ]; then
-    echo revsback=$REVSBACK
-    echo diffoptions=$DIFFOPTIONS
-    echo files=$FILES
+    echo revsback="$REVSBACK"
+    echo diffoptions="$DIFFOPTIONS"
+    echo files="$FILES"
 fi
 
 for FN in $FILES; do
     if [ -d "$FN" ]; then
-	echo "Skipping directory $FN"
+    echo "Skipping directory $FN"
     else
-	CURREV=`cvs -n stat $FN | grep 'Working revision' | awk '{print $3}'`
-	RC=$?
-	if [ "$RC" != 0 ]; then
-	    exit $RC;
-	fi
-	if [ "$CURREV" = "No" ]; then
-	    echo "$FN:  No CVS entry"
-	    continue;
-	fi
+    CURREV=$(cvs -n stat "$FN" | grep 'Working revision' | awk '{print $3}')
+    RC=$?
+    if [ "$RC" != 0 ]; then
+        exit $RC;
+    fi
+    if [ "$CURREV" = "No" ]; then
+        echo "$FN:  No CVS entry"
+        continue;
+    fi
 
-	LASTDIGITOFCUR=`echo $CURREV | awk -F. '{print ($NF)}'`
-	LASTDIGITOFPREV=`echo $CURREV | awk -F. '{print ($NF)-1}'`
-	if [ "$LASTDIGITOFCUR" -lt "$REVSBACK" ]; then
-	    echo "$FN:  there are only $LASTDIGITOFCUR revision(s) on this branch.  Nothing to diff."
-	    continue;
-	elif [ "$LASTDIGITOFCUR" -eq "$REVSBACK" ]; then
-	    PREVREV=`echo  $CURREV | sed -e 's/\.[0-9]*\.[0-9]*$//'`
-	    echo "$FN:  diffing with branch point..."
-	elif [ "$LASTDIGITOFPREV" -eq 0 ]; then
-	    PREVREV=`echo  $CURREV | sed -e 's/\.[0-9]*\.[0-9]*$//'`
-	    if [ -z "$PREVREV" ]; then
-		echo "$FN:  the current revision is the first one.  Nothing to diff."
-		continue;
-	    fi
-#	    echo "$FN:  the current revision is the first one on this branch..."
-#	    diff PREVREV and CURREV
-	else
-	    PREVREV=`echo $CURREV | awk -F. '{for (i=1; i < NF; ++i) \
-		    printf( "%s.", $i ); print ($NF)-revsback}' revsback=$REVSBACK`
-	fi
-	echo cvs -n diff $DIFFOPTIONS -r $PREVREV -r $CURREV $FN
-	if [ $EXECUTE -ne 0 ]; then
-	    cvs -n diff $DIFFOPTIONS -r $PREVREV -r $CURREV $FN
-	fi
+    LASTDIGITOFCUR=$(echo "$CURREV" | awk -F. '{print ($NF)}')
+    LASTDIGITOFPREV=$(echo "$CURREV" | awk -F. '{print ($NF)-1}')
+    if [ "$LASTDIGITOFCUR" -lt "$REVSBACK" ]; then
+        echo "$FN:  there are only $LASTDIGITOFCUR revision(s) on this branch.  Nothing to diff."
+        continue;
+    elif [ "$LASTDIGITOFCUR" -eq "$REVSBACK" ]; then
+        PREVREV=$(echo  "$CURREV" | sed -e 's/\.[0-9]*\.[0-9]*$//')
+        echo "$FN:  diffing with branch point..."
+    elif [ "$LASTDIGITOFPREV" -eq 0 ]; then
+        PREVREV=$(echo  "$CURREV" | sed -e 's/\.[0-9]*\.[0-9]*$//')
+        if [ -z "$PREVREV" ]; then
+        echo "$FN:  the current revision is the first one.  Nothing to diff."
+        continue;
+        fi
+#       echo "$FN:  the current revision is the first one on this branch..."
+#       diff PREVREV and CURREV
+    else
+        PREVREV=$(echo "$CURREV" | awk -F. '{for (i=1; i < NF; ++i) \
+            printf( "%s.", $i ); print ($NF)-revsback}' revsback="$REVSBACK")
+    fi
+    echo cvs -n diff "$DIFFOPTIONS" -r "$PREVREV" -r "$CURREV" "$FN"
+    if [ $EXECUTE -ne 0 ]; then
+        cvs -n diff "$DIFFOPTIONS" -r "$PREVREV" -r "$CURREV" "$FN"
+    fi
     fi
 done

--- a/tools/cvs-tools/cvslb
+++ b/tools/cvs-tools/cvslb
@@ -25,7 +25,7 @@
 # the Initial Developer. All Rights Reserved.
 # 
 # Contributor(s):
-#	Mark Smith <MarkCSmithWork@aol.com>
+#   Mark Smith <MarkCSmithWork@aol.com>
 # 
 # Alternatively, the contents of this file may be used under the terms of
 # either of the GNU General Public License Version 2 or later (the "GPL"),
@@ -51,7 +51,7 @@
 # options can also be passed in the CVSLBOPTIONS environment variable.
 #
 
-PROG=`basename $0`
+PROG=$(basename "$0")
 USAGE="$0 [-v] [ -l count ] [ -b branch ] [ file... ]"
 SEP="=============================================================================="
 REVLIMIT=0
@@ -60,158 +60,160 @@ VERBOSE=0
 
 
 # process arguments
-set -- `getopt vb:l: $CVSLBOPTIONS $*`
+set -- "$(getopt vb:l: "$CVSLBOPTIONS" "$*")"
 if [ $? != 0 ]; then
-   echo $USAGE
+   echo "$USAGE"
    exit 2
 fi
 
-for i in $*; do
+for i in "$@"; do
     case $i in
        -l) REVLIMIT=$2; shift 2;;
        -b) BRANCH=$2; shift 2;;
-       -v) VERBOSE=`expr $VERBOSE + 1`; shift;;
+       -v) VERBOSE=$(expr "$VERBOSE" + 1); shift;;
        --) shift; break;;
    esac
 done
 
 if [ $# -eq 0 ]; then
+    # Fixing this requires changing shell as arrays are not supported with /sh
+    # shellcheck disable=SC2125
     FILES=*
 else
     FILES=$*
 fi
 
 for FN in $FILES; do
-    if [ -d $FN ]; then
-	echo "$PROG: Skipping directory $FN..."
+    if [ -d "$FN" ]; then
+    echo "$PROG: Skipping directory $FN..."
     else
-	if [ -z "$BRANCH" ]; then
-	    LINE=`cvs -n stat $FN | grep 'Sticky Tag:'`
-	    RC=$?
-	    if [ $RC != 0 ]; then
-		echo "$PROG: skipping $FN (cvs stat failed or no sticky tag)..."
-		continue
-	    fi
+    if [ -z "$BRANCH" ]; then
+        LINE=$(cvs -n stat "$FN" | grep 'Sticky Tag:')
+        RC=$?
+        if [ $RC != 0 ]; then
+        echo "$PROG: skipping $FN (cvs stat failed or no sticky tag)..."
+        continue
+        fi
 
-	    CURTAG=`echo $LINE | awk '{print $3}'`
-	    if [ $CURTAG = "(none)" ]; then
-		    CURTAG="";
-	    fi
-	else
-	    if [ $BRANCH = "TRUNK" ]; then
-		CURTAG=""
-	    else
-		CURTAG=$BRANCH
-	    fi
-	fi
+        CURTAG=$(echo "$LINE" | awk '{print $3}')
+        if [ "$CURTAG" = "(none)" ]; then
+            CURTAG="";
+        fi
+    else
+        if [ "$BRANCH" = "TRUNK" ]; then
+        CURTAG=""
+        else
+        CURTAG=$BRANCH
+        fi
+    fi
 
-	if [ -z "$CURTAG" ]; then
-		DISPLAY_CURTAG="the trunk";
-	else
-		DISPLAY_CURTAG="$CURTAG";
-	fi
+    if [ -z "$CURTAG" ]; then
+        DISPLAY_CURTAG="the trunk";
+    else
+        DISPLAY_CURTAG="$CURTAG";
+    fi
 
-	if [ $VERBOSE -gt 0 ]; then
-	    echo $FN: current revision: $DISPLAY_CURTAG
-	fi
+    if [ "$VERBOSE" -gt 0 ]; then
+        echo "$FN": current revision: "$DISPLAY_CURTAG"
+    fi
 
-	cvs -n log $FN | awk '
-	BEGIN			{
-	    echoing = 1;
-	    no_more = 0;
-	}
-	/^symbolic names:/	{
-	    looking_for_branch = 1;
-	    echoing = 0;
-	    next;
-	}
-	/^description:/	{
-	    print;
-	    echoing = 1;
-	    if ( revlimit > 0 ) {
-		printf( "Displaying at most %d revisions from %s:\n", \
-			revlimit, display_curtag );
-	    } else {
-		printf( "Displaying all revisions from %s:\n", display_curtag );
-	    }
-	    next;
-	}
-	/^========================================================/ {
-	    next;
-	}
-	/^total revisions:/	{
-	    if ( looking_for_branch ) {
-		if ( curtag == "" ) {
-		    looking_for_branch = 0;
-		} else {
-		    printf( "This file not on branch %s (?)\n", display_curtag );
-		    exit;
-		}
-	    }
-	}
-	/^revision [0-9]*\.[0-9]*$/ {
-	    found_rev = 0;
-	    if ( !no_more && !looking_for_branch && curtag == "" ) {
-		if ( revlimit > 0 && --revlimit <= 0 ) {
-		    no_more = 1;
-		}
-		print;
-		echoing = 1;
-	    } else {
-		echoing = 0;
-	    }
-	    next;
-	}
-	/^revision [0-9]/	{
-	    found_rev = 0;
-	    if ( !no_more && !looking_for_branch ) {
-		 if ( length( $2 ) > numerictaglen &&		\
-			substr( $2, 1, numerictaglen ) == numerictag &&	\
-			index( substr( $2, numerictaglen + 1 ), "." ) == 0 ) {
-		    found_rev = 1;
-		}
-	    }
-	    if ( found_rev ) {
-		if ( revlimit > 0 && --revlimit <= 0 ) {
-		    no_more = 1;
-		}
-		print;
-		echoing = 1;
-	    } else {
-		echoing = 0;
-	    }
-	    next;
-	}
-	/	.*: [0-9]/	{
-	    tag = substr( $1, 1, length( $1 ) - 1 );
-	    if ( looking_for_branch && tag == curtag ) {
-		print;
-		count = split($2,digits,".");
-		numerictag="";
-		zero_suppressed = 0;
-		for ( i = 1; i <= count; ++i ) {
-		    if ( !zero_suppressed && digits[i] == "0" ) {
-			zero_suppressed = 1;
-		    } else {
-			numerictag = numerictag digits[i] ".";
-		    }
-		}
-		numerictaglen = length( numerictag );
-		looking_for_branch = 0;
-#		printf( "got branch: %s ($2 was %s)\n", numerictag, $2 );
-	    } else if ( echoing ) {
-		print;
-	    }
-	    next;
-	 }
-	/.*/			{
-	    if ( echoing ) {
-		print;
-	    }
-	    next;
-	}
-	' curtag="$CURTAG" display_curtag="$DISPLAY_CURTAG" revlimit="$REVLIMIT"
-	echo $SEP
+    cvs -n log "$FN" | awk '
+    BEGIN           {
+        echoing = 1;
+        no_more = 0;
+    }
+    /^symbolic names:/  {
+        looking_for_branch = 1;
+        echoing = 0;
+        next;
+    }
+    /^description:/ {
+        print;
+        echoing = 1;
+        if ( revlimit > 0 ) {
+        printf( "Displaying at most %d revisions from %s:\n", \
+            revlimit, display_curtag );
+        } else {
+        printf( "Displaying all revisions from %s:\n", display_curtag );
+        }
+        next;
+    }
+    /^========================================================/ {
+        next;
+    }
+    /^total revisions:/ {
+        if ( looking_for_branch ) {
+        if ( curtag == "" ) {
+            looking_for_branch = 0;
+        } else {
+            printf( "This file not on branch %s (?)\n", display_curtag );
+            exit;
+        }
+        }
+    }
+    /^revision [0-9]*\.[0-9]*$/ {
+        found_rev = 0;
+        if ( !no_more && !looking_for_branch && curtag == "" ) {
+        if ( revlimit > 0 && --revlimit <= 0 ) {
+            no_more = 1;
+        }
+        print;
+        echoing = 1;
+        } else {
+        echoing = 0;
+        }
+        next;
+    }
+    /^revision [0-9]/   {
+        found_rev = 0;
+        if ( !no_more && !looking_for_branch ) {
+         if ( length( $2 ) > numerictaglen &&       \
+            substr( $2, 1, numerictaglen ) == numerictag && \
+            index( substr( $2, numerictaglen + 1 ), "." ) == 0 ) {
+            found_rev = 1;
+        }
+        }
+        if ( found_rev ) {
+        if ( revlimit > 0 && --revlimit <= 0 ) {
+            no_more = 1;
+        }
+        print;
+        echoing = 1;
+        } else {
+        echoing = 0;
+        }
+        next;
+    }
+    /   .*: [0-9]/  {
+        tag = substr( $1, 1, length( $1 ) - 1 );
+        if ( looking_for_branch && tag == curtag ) {
+        print;
+        count = split($2,digits,".");
+        numerictag="";
+        zero_suppressed = 0;
+        for ( i = 1; i <= count; ++i ) {
+            if ( !zero_suppressed && digits[i] == "0" ) {
+            zero_suppressed = 1;
+            } else {
+            numerictag = numerictag digits[i] ".";
+            }
+        }
+        numerictaglen = length( numerictag );
+        looking_for_branch = 0;
+#       printf( "got branch: %s ($2 was %s)\n", numerictag, $2 );
+        } else if ( echoing ) {
+        print;
+        }
+        next;
+     }
+    /.*/            {
+        if ( echoing ) {
+        print;
+        }
+        next;
+    }
+    ' curtag="$CURTAG" display_curtag="$DISPLAY_CURTAG" revlimit="$REVLIMIT"
+    echo $SEP
     fi
 done
 

--- a/tools/ldap/test-c-sdk
+++ b/tools/ldap/test-c-sdk
@@ -23,7 +23,7 @@
 # the Initial Developer. All Rights Reserved.
 # 
 # Contributor(s):
-#	Mark Smith <MarkCSmithWork@aol.com>
+#   Mark Smith <MarkCSmithWork@aol.com>
 # 
 # Alternatively, the contents of this file may be used under the terms of
 # either of the GNU General Public License Version 2 or later (the "GPL"),
@@ -40,7 +40,7 @@
 # ***** END LICENSE BLOCK ***** 
 
 #UNAME=c:/appls/relbld-tools/gmake3.76.1/uname.exe
-UNAME=uname
+UNAME="uname"
 #
 # Perform a sanity check on the LDAP C SDK by executing the command line tools
 #
@@ -52,8 +52,8 @@ UNAME=uname
 
 usage()
 {
-	echo "usage: $0 [-v] [-c] [-s] [-3] [-C] [-b basedn] [-d debuglevel] [-h server] [-p ldap-port] [-P ldaps-port] [-W ssl-keyfile-passwd] [-L extra-lib-path ]" 2>&1
-	exit 2
+    echo "usage: $0 [-v] [-c] [-s] [-3] [-C] [-b basedn] [-d debuglevel] [-h server] [-p ldap-port] [-P ldaps-port] [-W ssl-keyfile-passwd] [-L extra-lib-path ]" 2>&1
+    exit 2
 }
 
 # By default, SSL tests are done.  -s turns them off.
@@ -89,56 +89,56 @@ EXTRA_SSL_ARGS=""
 
 #set - - `getopt vb:d:h:p:P: $*`
 #if [ $? != 0 ]; then
-#	usage;
+#   usage;
 #fi
 #for i in $*; do
 #echo $i
-#	case $i in
-#		-v)		VERBOSE=1;;
-#		-b)		LDAPBASE=$2; shift 2;;
-#		-d)		LDAPDEBUG=$2; shift 2;;
-#		-h)		LDAPHOST=$2; shift 2;;
-#		-p)		LDAPPORT=$2; shift 2;;
-#		-P)		LDAPSPORT=$2; shift 2;;
-#	esac
+#   case $i in
+#       -v)     VERBOSE=1;;
+#       -b)     LDAPBASE=$2; shift 2;;
+#       -d)     LDAPDEBUG=$2; shift 2;;
+#       -h)     LDAPHOST=$2; shift 2;;
+#       -p)     LDAPPORT=$2; shift 2;;
+#       -P)     LDAPSPORT=$2; shift 2;;
+#   esac
 #done
 
 while getopts vcCs3b:d:h:L:p:P:W: c; do
-	case $c in
-		v)	if [ $VERBOSE -eq 1 ]; then
-				REALLY_VERBOSE=1;
-			else
-				VERBOSE=1
-			fi
-		;;
-		c)	STOP_ON_ERRORS=0;;
-		C)	COPY_ROOT_CERT_LIB=1;;
-		s)	TEST_SSL="no";;
-		3)	EXTRA_SSL_ARGS="$EXTRA_SSL_ARGS -3";;
-		b)	LDAPBASE=$OPTARG;;
-		d)	LDAPDEBUG=$OPTARG;;
-		h)	LDAPHOST=$OPTARG;;
-		L)	EXTRA_LIB_PATH=$OPTARG;;
-		p)	LDAPPORT=$OPTARG;;
-		P)	LDAPSPORT=$OPTARG;;
-		W)	KEYPASSWD=$OPTARG;;
+    case $c in
+        v)  if [ $VERBOSE -eq 1 ]; then
+                REALLY_VERBOSE=1;
+            else
+                VERBOSE=1
+            fi
+        ;;
+        c)  STOP_ON_ERRORS=0;;
+        C)  COPY_ROOT_CERT_LIB=1;;
+        s)  TEST_SSL="no";;
+        3)  EXTRA_SSL_ARGS="$EXTRA_SSL_ARGS -3";;
+        b)  LDAPBASE=$OPTARG;;
+        d)  LDAPDEBUG=$OPTARG;;
+        h)  LDAPHOST=$OPTARG;;
+        L)  EXTRA_LIB_PATH=$OPTARG;;
+        p)  LDAPPORT=$OPTARG;;
+        P)  LDAPSPORT=$OPTARG;;
+        W)  KEYPASSWD=$OPTARG;;
 
-		\?)	usage;;
-	esac
+        \?) usage;;
+    esac
 done
-shift `expr $OPTIND - 1`
+shift "$(expr $OPTIND - 1)"
 
-if [ -z "$KEYPASSWD" -a z$TEST_SSL = z"yes" ]; then
-	echo "Please provide the keyfile password (-W password)"
-	usage;
+if [ -z "$KEYPASSWD" ] && [ z$TEST_SSL = z"yes" ]; then
+    echo "Please provide the keyfile password (-W password)"
+    usage;
 fi
 
 if [ $# -gt 0 ]; then
-	usage;
+    usage;
 fi
 
 if [ $REALLY_VERBOSE -ne 0 ]; then
-	TOOLS_OUTFILE=/dev/tty
+    TOOLS_OUTFILE=/dev/tty
 fi
 
 DEV_NULL=/dev/null
@@ -146,54 +146,54 @@ BUILD_VARIANTS="DBG.OBJ OPT.OBJ"
 
 ICONV_SRC_CHARSET=ISO8859-1
 ICONV_UTF8_CHARSET=UTF-8
-OS=`$UNAME`
+OS=$($UNAME)
 case $OS in
-	SunOS)
-		if [ `$UNAME -r` = "5.6" ]; then
-			ICONV_SRC_CHARSET=8859-1
-		fi
-		OS_VARIANTS="SunOS5.6 SunOS5.8 SunOS5.8_64"
-		LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
-		;;
-	HP-UX)
-		OS_VARIANTS="HP-UXB.11.00 HP-UXB.11.00_64"
-		LDAPTOOL_LC_CTYPE=en_US.iso88591
-		ICONV_SRC_CHARSET=iso8859_1
-		ICONV_UTF8_CHARSET=utf8
-		;;
-	AIX)
-		OS_VARIANTS="AIX4.3"
-		LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
-		;;
-	Linux)
-		OS_VARIANTS="Linux2.2_x86_glibc_PTH Linux2.4_x86_glibc_PTH"
-		LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
-		ICONV_SRC_CHARSET=ISO-8859-1
-		;;
-	WINNT)
-		OS_VARIANTS="WINNT5.0"
-		BUILD_VARIANTS="$BUILD_VARIANTS DBG.OBJD"
-		CERTDB=c:/Dev/test/ldapcsdk/client-kvaughan-db-10-2003
-		DEV_NULL="nul:"
-		;;
-	*)
-		echo "unknown operating system $OS" 2>&1
-		exit 1
+    SunOS)
+        if [ "$($UNAME -r)" = "5.6" ]; then
+            ICONV_SRC_CHARSET=8859-1
+        fi
+        OS_VARIANTS="SunOS5.6 SunOS5.8 SunOS5.8_64"
+        LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
+        ;;
+    HP-UX)
+        OS_VARIANTS="HP-UXB.11.00 HP-UXB.11.00_64"
+        LDAPTOOL_LC_CTYPE=en_US.iso88591
+        ICONV_SRC_CHARSET=iso8859_1
+        ICONV_UTF8_CHARSET=utf8
+        ;;
+    AIX)
+        OS_VARIANTS="AIX4.3"
+        LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
+        ;;
+    Linux)
+        OS_VARIANTS="Linux2.2_x86_glibc_PTH Linux2.4_x86_glibc_PTH"
+        LDAPTOOL_LC_CTYPE=en_US.ISO8859-1
+        ICONV_SRC_CHARSET=ISO-8859-1
+        ;;
+    WINNT)
+        OS_VARIANTS="WINNT5.0"
+        BUILD_VARIANTS="$BUILD_VARIANTS DBG.OBJD"
+        CERTDB=c:/Dev/test/ldapcsdk/client-kvaughan-db-10-2003
+        DEV_NULL="nul:"
+        ;;
+    *)
+        echo "unknown operating system $OS" 2>&1
+        exit 1
 esac
 
 # set up locale environment (charset)
-if [ $OS != WINNT ]; then
-	LC_ALL=$LDAPTOOL_LC_CTYPE; export LC_ALL
-	if [ $VERBOSE -ne 0 ]; then
-		echo "$0: LC_ALL=$LDAPTOOL_LC_CTYPE"
-		locale
-	fi
+if [ "$OS" != WINNT ]; then
+    LC_ALL=$LDAPTOOL_LC_CTYPE; export LC_ALL
+    if [ $VERBOSE -ne 0 ]; then
+        echo "$0: LC_ALL=$LDAPTOOL_LC_CTYPE"
+        locale
+    fi
 fi
 
 if [ "$OS" = "WINNT" ]; then
-	CMD_TO_UTF8=cat
+    CMD_TO_UTF8="cat"
 else
-	CMD_TO_UTF8="iconv -f $ICONV_SRC_CHARSET -t $ICONV_UTF8_CHARSET"
+    CMD_TO_UTF8="iconv -f $ICONV_SRC_CHARSET -t $ICONV_UTF8_CHARSET"
 fi
 
 
@@ -203,12 +203,12 @@ TEST_MODIFIES=yes
 # moddn, etc.
 TEST_MODDNNEWSUP=no
 
-if [ ! -z "$LDAPDEBUG" ]; then
-	DEBUG_ARG="-d $LDAPDEBUG"
+if [ -n "$LDAPDEBUG" ]; then
+    DEBUG_ARG="-d $LDAPDEBUG"
 fi
 
 if [ $VERBOSE -ne 0 ]; then
-	VERBOSE_ARG="-v"
+    VERBOSE_ARG="-v"
 fi
 
 SEP="++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
@@ -217,313 +217,313 @@ SEP="++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 # OS, OBJDIR, NSS_RELEASE, and NSPR_RELEASE must be set
 setup_shlib_access()
 {
-	NSS_LIB_PATH="$NSS_RELEASE_ROOT/$NSS_RELEASE/$OBJDIR/lib"
-	NSPR_LIB_PATH="$NSPR_RELEASE_ROOT/$NSPR_RELEASE/$OBJDIR/lib"
-	if [ -z "$EXTRA_LIB_PATH" ]; then
-		SHARED_LIB_PATH=$NSS_LIB_PATH:$NSPR_LIB_PATH
-	else
-		SHARED_LIB_PATH=$NSS_LIB_PATH:$NSPR_LIB_PATH:$EXTRA_LIB_PATH
-	fi
+    NSS_LIB_PATH="$NSS_RELEASE_ROOT/$NSS_RELEASE/$OBJDIR/lib"
+    NSPR_LIB_PATH="$NSPR_RELEASE_ROOT/$NSPR_RELEASE/$OBJDIR/lib"
+    if [ -z "$EXTRA_LIB_PATH" ]; then
+        SHARED_LIB_PATH=$NSS_LIB_PATH:$NSPR_LIB_PATH
+    else
+        SHARED_LIB_PATH=$NSS_LIB_PATH:$NSPR_LIB_PATH:$EXTRA_LIB_PATH
+    fi
 
-	case $OS in
-		SunOS|IRIX)
-			LD_LIBRARY_PATH=$SHARED_LIB_PATH;
-			export LD_LIBRARY_PATH;
-			ROOT_CERT_SO=libnssckbi.so
-			;;
-		HP-UX)
-			SHLIB_PATH=$SHARED_LIB_PATH;
-			export SHLIB_PATH;
-			ROOT_CERT_SO=libnssckbi.sl
-			;;
-		AIX)
-			LIBPATH=$SHARED_LIB_PATH;
-			export LIBPATH;
-			ROOT_CERT_SO=libnssckbi.so
-			;;
-		Linux)
-			LD_LIBRARY_PATH=$SHARED_LIB_PATH;
-			export LD_LIBRARY_PATH;
-			ROOT_CERT_SO=libnssckbi.so
-			;;
-		WINNT)
-			PATH="`pwd`/$OBJDIR/lib;:$PATH;"
-			export PATH;
-			ROOT_CERT_SO=nssckbi.dll
-			;;
-		*)
-			echo "setup_shlib_access: unknown operating system $OS" 2>&1
-			exit 1
-	esac
+    case $OS in
+        SunOS|IRIX)
+            LD_LIBRARY_PATH=$SHARED_LIB_PATH;
+            export LD_LIBRARY_PATH;
+            ROOT_CERT_SO=libnssckbi.so
+            ;;
+        HP-UX)
+            SHLIB_PATH=$SHARED_LIB_PATH;
+            export SHLIB_PATH;
+            ROOT_CERT_SO=libnssckbi.sl
+            ;;
+        AIX)
+            LIBPATH=$SHARED_LIB_PATH;
+            export LIBPATH;
+            ROOT_CERT_SO=libnssckbi.so
+            ;;
+        Linux)
+            LD_LIBRARY_PATH=$SHARED_LIB_PATH;
+            export LD_LIBRARY_PATH;
+            ROOT_CERT_SO=libnssckbi.so
+            ;;
+        WINNT)
+            PATH="$(pwd)/$OBJDIR/lib;:$PATH;"
+            export PATH;
+            ROOT_CERT_SO=nssckbi.dll
+            ;;
+        *)
+            echo "setup_shlib_access: unknown operating system $OS" 2>&1
+            exit 1
+    esac
 
-	if [ z$TEST_SSL = z"yes" ]; then
+    if [ z$TEST_SSL = z"yes" ]; then
 # Copy root cert shared library to cert DB location
-		ROOT_CERT_SO_DST_PATH=$CERTDB/$ROOT_CERT_SO
-		if [ "$COPY_ROOT_CERT_LIB" -ne 0 ]; then
-			echo setup_shlib_access: cp -p $NSS_LIB_PATH/$ROOT_CERT_SO $ROOT_CERT_SO_DST_PATH
-			cp -p $NSS_LIB_PATH/$ROOT_CERT_SO $ROOT_CERT_SO_DST_PATH
-		fi
-	fi
+        ROOT_CERT_SO_DST_PATH=$CERTDB/$ROOT_CERT_SO
+        if [ "$COPY_ROOT_CERT_LIB" -ne 0 ]; then
+            echo setup_shlib_access: cp -p "$NSS_LIB_PATH"/$ROOT_CERT_SO $ROOT_CERT_SO_DST_PATH
+            cp -p "$NSS_LIB_PATH"/$ROOT_CERT_SO $ROOT_CERT_SO_DST_PATH
+        fi
+    fi
 }
 
 
 # ROOT_CERT_SO_DST_PATH must be set
 cleanup_shlib_access()
 {
-	if [ "$COPY_ROOT_CERT_LIB" -ne 0 ]; then
-		echo cleanup_shlib_access: rm $ROOT_CERT_SO_DST_PATH
-		rm $ROOT_CERT_SO_DST_PATH
-	fi
+    if [ "$COPY_ROOT_CERT_LIB" -ne 0 ]; then
+        echo cleanup_shlib_access: rm "$ROOT_CERT_SO_DST_PATH"
+        rm "$ROOT_CERT_SO_DST_PATH"
+    fi
 }
 
 
 # OBJDIR and OS must be set
 test_one()
 {
-	TEST_ONE_RC=0
+    TEST_ONE_RC=0
 
     if [ "$OS" = "WINNT" ]; then
-#		echo "cd $OBJDIR/lib"
-#		cd $OBJDIR/lib
-#		LDAPTOOLSDIR=../tools
-		LDAPTOOLSDIR=$OBJDIR/tools
-	else
-		echo "cd $OBJDIR/tools"
-		cd $OBJDIR/tools
-		LDAPTOOLSDIR=.
-	fi
+#       echo "cd $OBJDIR/lib"
+#       cd $OBJDIR/lib
+#       LDAPTOOLSDIR=../tools
+        LDAPTOOLSDIR=$OBJDIR/tools
+    else
+        echo "cd $OBJDIR/tools"
+        cd "$OBJDIR"/tools || exit
+        LDAPTOOLSDIR=.
+    fi
 
-	if [ z$TEST_SEARCHES = z"yes" ]; then
-	# test searches
+    if [ z$TEST_SEARCHES = z"yes" ]; then
+    # test searches
 
-	echo search1 $SEP
-	$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT \
-		-b "$LDAPBASE" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE search1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    echo search1 $SEP
+    "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -b "$LDAPBASE" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE search1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	if [ z$TEST_SSL = z"yes" ]; then
-		echo sslsearch1 $SEP
-		$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-			-h $LDAPHOST -p $LDAPSPORT \
-			-b "$LDAPBASE" $EXTRA_SSL_ARGS -Z -P $CERTDB \
-			'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
-		TOOLS_RC=$?
-		if [ $TOOLS_RC -ne 0 ]; then
-			echo "** FAILURE sslsearch1 ($TOOLS_RC)";
-			if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-			TEST_ONE_RC=$TOOLS_RC;
-		fi
+    if [ z$TEST_SSL = z"yes" ]; then
+        echo sslsearch1 $SEP
+        "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+            -h "$LDAPHOST" -p "$LDAPSPORT" \
+            -b "$LDAPBASE" "$EXTRA_SSL_ARGS" -Z -P $CERTDB \
+            'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
+        TOOLS_RC=$?
+        if [ $TOOLS_RC -ne 0 ]; then
+            echo "** FAILURE sslsearch1 ($TOOLS_RC)";
+            if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+            TEST_ONE_RC=$TOOLS_RC;
+        fi
 
-		if [ z$TEST_SSL_CLIENT_AUTH = z"yes" ]; then
-			echo sslsearch2-clientauth $SEP
-			$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-				-h $LDAPHOST -p $LDAPSPORT \
-				-b "" -s base $EXTRA_SSL_ARGS -Z -P $CERTDB -N "$CERTNAME" \
-				-W "$KEYPASSWD" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
-			TOOLS_RC=$?
-			if [ $TOOLS_RC -ne 0 ]; then
-				echo "** FAILURE sslsearch2 ($TOOLS_RC)";
-				if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-				TEST_ONE_RC=$TOOLS_RC;
-			fi
-		fi
-		# end of SSL client auth search tests
+        if [ z$TEST_SSL_CLIENT_AUTH = z"yes" ]; then
+            echo sslsearch2-clientauth $SEP
+            "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+                -h "$LDAPHOST" -p "$LDAPSPORT" \
+                -b "" -s base "$EXTRA_SSL_ARGS" -Z -P $CERTDB -N "$CERTNAME" \
+                -W "$KEYPASSWD" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
+            TOOLS_RC=$?
+            if [ $TOOLS_RC -ne 0 ]; then
+                echo "** FAILURE sslsearch2 ($TOOLS_RC)";
+                if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+                TEST_ONE_RC=$TOOLS_RC;
+            fi
+        fi
+        # end of SSL client auth search tests
 
-	fi
-	# end of SSL search tests
+    fi
+    # end of SSL search tests
 
 fi
 # end of search tests
 
 if [ z$TEST_MODIFIES = z"yes" ]; then
-	# modify
+    # modify
 
-	echo modify1 $SEP
-	$LDAPTOOLSDIR/ldapmodify $VERBOSE_ARG $DEBUG_ARG -a \
-		-h $LDAPHOST -p $LDAPPORT \
-		-D "$BINDDN" -w "$BINDPW" <<MOD1 > $TOOLS_OUTFILE
+    echo modify1 $SEP
+    "$LDAPTOOLSDIR"/ldapmodify "$VERBOSE_ARG" "$DEBUG_ARG" -a \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -D "$BINDDN" -w "$BINDPW" <<MOD1 > $TOOLS_OUTFILE
 dn: cn=Test Entry, $LDAPBASE
 cn: Test Entry
 sn: Entry
 objectClass: person
 MOD1
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE modify1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE modify1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	echo modverifysearch1 $SEP
-	$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT \
-		-b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE modverifysearch1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    echo modverifysearch1 $SEP
+    "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE modverifysearch1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	# I18n modify and search
-	echo i18nmodify1 $SEP
-	LAST_ENTRY_DN_88591="cn=á with accent Entry,$LDAPBASE"
-	LAST_ENTRY_DN_UTF8="cn=\C3\A1 with accent Entry,$LDAPBASE"
+    # I18n modify and search
+    echo i18nmodify1 $SEP
+    LAST_ENTRY_DN_88591="cn=ï¿½ with accent Entry,$LDAPBASE"
+    LAST_ENTRY_DN_UTF8="cn=\C3\A1 with accent Entry,$LDAPBASE"
 
-if [ $OS != WINNT ]; then
-	$CMD_TO_UTF8 <<I18NMOD1 > $TOOLS_TMPFILE
+if [ "$OS" != WINNT ]; then
+    $CMD_TO_UTF8 <<I18NMOD1 > $TOOLS_TMPFILE
 dn: $LAST_ENTRY_DN_88591
-cn: á with accent Entry
+cn: ï¿½ with accent Entry
 sn: A Entry
 objectClass: person
 I18NMOD1
 else
-	cat <<I18NMOD1b > $TOOLS_TMPFILE
+    cat <<I18NMOD1b > $TOOLS_TMPFILE
 dn: $LAST_ENTRY_DN_UTF8
 sn: A Entry
 objectClass: person
 I18NMOD1b
 fi
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		rm $TOOLS_TMPFILE
-		echo "** FAILURE $CMD_TO_UTF8 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        rm $TOOLS_TMPFILE
+        echo "** FAILURE $CMD_TO_UTF8 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	$LDAPTOOLSDIR/ldapmodify $VERBOSE_ARG $DEBUG_ARG -a \
-		-h $LDAPHOST -p $LDAPPORT \
-		-D "$BINDDN" -w "$BINDPW" < $TOOLS_TMPFILE > $TOOLS_OUTFILE
-	TOOLS_RC=$?
-	rm $TOOLS_TMPFILE
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE i18nmodify1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    "$LDAPTOOLSDIR"/ldapmodify "$VERBOSE_ARG" "$DEBUG_ARG" -a \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -D "$BINDDN" -w "$BINDPW" < $TOOLS_TMPFILE > $TOOLS_OUTFILE
+    TOOLS_RC=$?
+    rm $TOOLS_TMPFILE
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE i18nmodify1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	echo i18nmodverifysearch1 $SEP
-	$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT -s base \
-		-b "$LAST_ENTRY_DN_88591" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE i18nmodverifysearch1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    echo i18nmodverifysearch1 $SEP
+    "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" -s base \
+        -b "$LAST_ENTRY_DN_88591" 'objectClass=*' > $TOOLS_OUTFILE < $DEV_NULL
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE i18nmodverifysearch1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	echo i18ndelete1 $SEP
-	$LDAPTOOLSDIR/ldapdelete $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT \
-		-D "$BINDDN" -w "$BINDPW" \
-		-i $ICONV_UTF8_CHARSET "$LAST_ENTRY_DN_UTF8" > $TOOLS_OUTFILE
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE i18ndelete1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    echo i18ndelete1 $SEP
+    "$LDAPTOOLSDIR"/ldapdelete "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -D "$BINDDN" -w "$BINDPW" \
+        -i $ICONV_UTF8_CHARSET "$LAST_ENTRY_DN_UTF8" > $TOOLS_OUTFILE
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE i18ndelete1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	# modrdn
-	echo modrdn1 $SEP
-	$LDAPTOOLSDIR/ldapmodify $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT \
-		-D "$BINDDN" -w "$BINDPW" <<MOD2 > $TOOLS_OUTFILE
+    # modrdn
+    echo modrdn1 $SEP
+    "$LDAPTOOLSDIR"/ldapmodify "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -D "$BINDDN" -w "$BINDPW" <<MOD2 > $TOOLS_OUTFILE
 dn: cn=Test Entry, $LDAPBASE
 changetype: modrdn
 newrdn: cn=Testy Entry
 deleteoldrdn: 0
 MOD2
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE modrdn1 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-			TEST_ONE_RC=$TOOLS_RC;
-	fi
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE modrdn1 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+            TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	LAST_ENTRY_DN="cn=Testy Entry, $LDAPBASE"
+    LAST_ENTRY_DN="cn=Testy Entry, $LDAPBASE"
 
-	echo modverifysearch2 $SEP
-	$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-		-h $LDAPHOST -p $LDAPPORT \
-		-b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
-	TOOLS_RC=$?
-	if [ $TOOLS_RC -ne 0 ]; then
-		echo "** FAILURE modverifysearch2 ($TOOLS_RC)";
-		if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-		TEST_ONE_RC=$TOOLS_RC;
-	fi
+    echo modverifysearch2 $SEP
+    "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+        -h "$LDAPHOST" -p "$LDAPPORT" \
+        -b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
+    TOOLS_RC=$?
+    if [ $TOOLS_RC -ne 0 ]; then
+        echo "** FAILURE modverifysearch2 ($TOOLS_RC)";
+        if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+        TEST_ONE_RC=$TOOLS_RC;
+    fi
 
-	if [ z$TEST_MODDNNEWSUP = z"yes" ]; then
-		# moddn with new superior
-		echo moddn1 $SEP
-		$LDAPTOOLSDIR/ldapmodify -V 3 $VERBOSE_ARG $DEBUG_ARG \
-			-h $LDAPHOST -p $LDAPPORT \
-			-D "$BINDDN" -w "$BINDPW" <<MOD3 > $TOOLS_OUTFILE
+    if [ z$TEST_MODDNNEWSUP = z"yes" ]; then
+        # moddn with new superior
+        echo moddn1 $SEP
+        "$LDAPTOOLSDIR"/ldapmodify -V 3 "$VERBOSE_ARG" "$DEBUG_ARG" \
+            -h "$LDAPHOST" -p "$LDAPPORT" \
+            -D "$BINDDN" -w "$BINDPW" <<MOD3 > $TOOLS_OUTFILE
 dn: cn=Test Entry, $LDAPBASE
 changetype: moddn
 newrdn: cn=Testier Entry
 deleteoldrdn: 0
 newparent: ou=People, $LDAPBASE
 MOD3
-		TOOLS_RC=$?
-		if [ $TOOLS_RC -ne 0 ]; then
-			echo "** FAILURE moddn1 ($TOOLS_RC)";
-			if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-			TEST_ONE_RC=$TOOLS_RC;
-		fi
+        TOOLS_RC=$?
+        if [ $TOOLS_RC -ne 0 ]; then
+            echo "** FAILURE moddn1 ($TOOLS_RC)";
+            if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+            TEST_ONE_RC=$TOOLS_RC;
+        fi
 
-		LAST_ENTRY_DN="cn=Testier Entry, ou=People, $LDAPBASE"
+        LAST_ENTRY_DN="cn=Testier Entry, ou=People, $LDAPBASE"
 
-		echo modverifysearch3 $SEP
-		$LDAPTOOLSDIR/ldapsearch $VERBOSE_ARG $DEBUG_ARG \
-			-h $LDAPHOST -p $LDAPPORT \
-			-b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
-		TOOLS_RC=$?
-		if [ $TOOLS_RC -ne 0 ]; then
-			echo "** FAILURE modverifysearch3 ($TOOLS_RC)";
-			if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-			TEST_ONE_RC=$TOOLS_RC;
-		fi
+        echo modverifysearch3 $SEP
+        "$LDAPTOOLSDIR"/ldapsearch "$VERBOSE_ARG" "$DEBUG_ARG" \
+            -h "$LDAPHOST" -p "$LDAPPORT" \
+            -b "$LDAPBASE" 'sn=Entry' > $TOOLS_OUTFILE < $DEV_NULL
+        TOOLS_RC=$?
+        if [ $TOOLS_RC -ne 0 ]; then
+            echo "** FAILURE modverifysearch3 ($TOOLS_RC)";
+            if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+            TEST_ONE_RC=$TOOLS_RC;
+        fi
 
-	# end of moddn with new superior tests
-	fi
+    # end of moddn with new superior tests
+    fi
 
-	if [ z$TEST_SSL = z"yes" ]; then
-		echo delete1 $SEP
-		$LDAPTOOLSDIR/ldapdelete $VERBOSE_ARG $DEBUG_ARG \
-			-h $LDAPHOST -p $LDAPSPORT \
-			-D "$BINDDN" -w "$BINDPW" $EXTRA_SSL_ARGS -Z -P $CERTDB \
-			 "$LAST_ENTRY_DN" > $TOOLS_OUTFILE
-			TOOLS_RC=$?
-			if [ $TOOLS_RC -ne 0 ]; then
-				echo "** FAILURE ssldelete1 ($TOOLS_RC)";
-				if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-				TEST_ONE_RC=$TOOLS_RC;
-			fi
+    if [ z$TEST_SSL = z"yes" ]; then
+        echo delete1 $SEP
+        "$LDAPTOOLSDIR"/ldapdelete "$VERBOSE_ARG" "$DEBUG_ARG" \
+            -h "$LDAPHOST" -p "$LDAPSPORT" \
+            -D "$BINDDN" -w "$BINDPW" "$EXTRA_SSL_ARGS" -Z -P $CERTDB \
+             "$LAST_ENTRY_DN" > $TOOLS_OUTFILE
+            TOOLS_RC=$?
+            if [ $TOOLS_RC -ne 0 ]; then
+                echo "** FAILURE ssldelete1 ($TOOLS_RC)";
+                if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+                TEST_ONE_RC=$TOOLS_RC;
+            fi
 
-	else
-		echo delete 1 $SEP
-		$LDAPTOOLSDIR/ldapdelete $VERBOSE_ARG $DEBUG_ARG \
-			-h $LDAPHOST -p $LDAPPORT \
-			-D "$BINDDN" -w "$BINDPW" \
-			"$LAST_ENTRY_DN" > $TOOLS_OUTFILE
-		TOOLS_RC=$?
-		if [ $TOOLS_RC -ne 0 ]; then
-			echo "** FAILURE delete1 ($TOOLS_RC)";
-			if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
-			TEST_ONE_RC=$TOOLS_RC;
-		fi
-	fi
-	# end of SSL or non-SSL delete test
+    else
+        echo delete 1 $SEP
+        "$LDAPTOOLSDIR"/ldapdelete "$VERBOSE_ARG" "$DEBUG_ARG" \
+            -h "$LDAPHOST" -p "$LDAPPORT" \
+            -D "$BINDDN" -w "$BINDPW" \
+            "$LAST_ENTRY_DN" > $TOOLS_OUTFILE
+        TOOLS_RC=$?
+        if [ $TOOLS_RC -ne 0 ]; then
+            echo "** FAILURE delete1 ($TOOLS_RC)";
+            if [ $STOP_ON_ERRORS -ne 0 ]; then return $TOOLS_RC; fi
+            TEST_ONE_RC=$TOOLS_RC;
+        fi
+    fi
+    # end of SSL or non-SSL delete test
 
 fi
 # end of modify tests
@@ -531,68 +531,68 @@ fi
 return $TEST_ONE_RC;
 }
 
-echo $0 started
-echo server:	$LDAPHOST:$LDAPPORT
-echo ssl:		$TEST_SSL		"(port $LDAPSPORT)"
-echo clientath:	$TEST_SSL_CLIENT_AUTH
-echo moddn:		$TEST_MODDNNEWSUP
-echo search:	$TEST_SEARCHES
-echo modify:	$TEST_MODIFIES
-echo nss:		$NSS_RELEASE
-echo nspr:		$NSPR_RELEASE
+echo "$0" started
+echo server:    "$LDAPHOST":"$LDAPPORT"
+echo ssl:       $TEST_SSL       "(port $LDAPSPORT)"
+echo clientath: $TEST_SSL_CLIENT_AUTH
+echo moddn:     $TEST_MODDNNEWSUP
+echo search:    $TEST_SEARCHES
+echo modify:    $TEST_MODIFIES
+echo nss:       $NSS_RELEASE
+echo nspr:      $NSPR_RELEASE
 
 RC=0
 TESTED_STR=""
 TESTED_COUNT=0
 TESTED_FAIL_COUNT=0
 TESTED_SKIP_COUNT=0
-HOMEBASE_DIR=`pwd`;
+HOMEBASE_DIR=$(pwd);
 for os in $OS_VARIANTS; do
-	for build in $BUILD_VARIANTS; do
-		OBJDIR="${os}_${build}"
-		echo ""
-		if [ ! -d "$OBJDIR" ]; then
-			echo "Skipping $OBJDIR (no such directory)..."
-			TESTED_SKIP_COUNT=`expr $TESTED_SKIP_COUNT + 1`;
-			continue;
-		fi
-		echo Testing $OBJDIR...
-		setup_shlib_access;
-		test_one;
-		ONE_RC=$?
-		cleanup_shlib_access;
-		TESTED_COUNT=`expr $TESTED_COUNT + 1`;
-		TESTED_STR="$TESTED_STR $OBJDIR";
-		if [ $ONE_RC -ne 0 ]; then
-			echo "** FAILURE $OBJDIR";
-			TESTED_FAIL_COUNT=`expr $TESTED_FAIL_COUNT + 1`;
-			if [ $STOP_ON_ERRORS -ne 0 ]; then
-				exit $ONE_RC;
-			else
-				RC=$ONE_RC;
-			fi
-		fi
-		cd $HOMEBASE_DIR
-	done
+    for build in $BUILD_VARIANTS; do
+        OBJDIR="${os}_${build}"
+        echo ""
+        if [ ! -d "$OBJDIR" ]; then
+            echo "Skipping $OBJDIR (no such directory)..."
+            TESTED_SKIP_COUNT=$(expr "$TESTED_SKIP_COUNT" + 1);
+            continue;
+        fi
+        echo Testing "$OBJDIR"...
+        setup_shlib_access;
+        test_one;
+        ONE_RC=$?
+        cleanup_shlib_access;
+        TESTED_COUNT=$(expr "$TESTED_COUNT" + 1);
+        TESTED_STR="$TESTED_STR $OBJDIR";
+        if [ $ONE_RC -ne 0 ]; then
+            echo "** FAILURE $OBJDIR";
+            TESTED_FAIL_COUNT=$(expr "$TESTED_FAIL_COUNT" + 1);
+            if [ $STOP_ON_ERRORS -ne 0 ]; then
+                exit $ONE_RC;
+            else
+                RC=$ONE_RC;
+            fi
+        fi
+        cd "$HOMEBASE_DIR" || exit
+    done
 done
 
 echo ""
 if [ "$TESTED_SKIP_COUNT" -gt 0 ]; then
-	SKIP_STR=" (skipped $TESTED_SKIP_COUNT tests)";
+    SKIP_STR=" (skipped $TESTED_SKIP_COUNT tests)";
 else
-	SKIP_STR="";
+    SKIP_STR="";
 fi
 if [ -z "$TESTED_STR" ]; then
-	echo "No tests executed$SKIP_STR."
-	RC=2;
+    echo "No tests executed$SKIP_STR."
+    RC=2;
 else
-	echo "Tested $TESTED_STR."
-	if [ "$ONE_RC" -eq 0 ]; then
-		echo "All $TESTED_COUNT tests completed OK$SKIP_STR."
-	else
-		echo "$TESTED_FAIL_COUNT tests of $TESTED_COUNT failed $SKIP_STR."
-	fi
+    echo "Tested $TESTED_STR."
+    if [ "$ONE_RC" -eq 0 ]; then
+        echo "All $TESTED_COUNT tests completed OK$SKIP_STR."
+    else
+        echo "$TESTED_FAIL_COUNT tests of $TESTED_COUNT failed $SKIP_STR."
+    fi
 fi
 
-echo $0 done.
+echo "$0" done.
 exit $RC


### PR DESCRIPTION
Some checks regarding shell incompatibility were ignored as changing
shell could have unforeseen consequences.

The file "configure" will be addressed separately due to it's size.