### PR TITLE
Update workflows to use not deeprecated actions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -30,7 +30,7 @@ jobs:
     container: fedora:${{ matrix.os }}
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -10,7 +10,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -28,13 +28,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -61,7 +61,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}    
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -107,7 +107,7 @@ jobs:
           echo ${{ github.event.pull_request.base.ref }} > ./pr/BaseBranch
 
       - name: Upload pr as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/
@@ -116,7 +116,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/ds-tests.yml
+++ b/.github/workflows/ds-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -29,13 +29,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ds-${{ matrix.os }}
           path: |
@@ -115,7 +115,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ds-ssl-${{ matrix.os }}
           path: |

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -11,7 +11,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -29,13 +29,13 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ca-${{ matrix.os }}
           path: |

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -14,7 +14,7 @@ jobs:
       pr-base: ${{ steps.pr-base-script.outputs.result }}
     steps:
       - name: 'Download PR artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         id: download-pr
         with:
           result-encoding: string
@@ -32,7 +32,7 @@ jobs:
               return "False";
             }
             var download = await github.actions.downloadArtifact({
-              owner: context.repo.owner,
+              owner: context.repo.owne6r,
               repo: context.repo.repo,
               artifact_id: matchArtifact.id,
               archive_format: 'zip',
@@ -48,7 +48,7 @@ jobs:
       - name: Retrieve the pr number
         if: success()
         id: pr-artifact-script
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
@@ -59,7 +59,7 @@ jobs:
       - name: Retrieve the pr base
         if: success()
         id: pr-base-script
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
@@ -76,7 +76,7 @@ jobs:
       repo: ${{ steps.init.outputs.repo }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -94,7 +94,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -108,10 +108,10 @@ jobs:
           git rebase ldap-sdk/${{ needs.retrieve-pr.outputs.pr-base }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -147,7 +147,7 @@ jobs:
         run: docker load --input sonar-runner.tar
 
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -8,7 +8,7 @@ else
 fi
 
 echo "MATRIX: $MATRIX"
-echo "::set-output name=matrix::$MATRIX"
+echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then
@@ -18,4 +18,4 @@ else
 fi
 
 echo "REPO: $REPO"
-echo "::set-output name=repo::$REPO"
+echo "repo=$REPO" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Some action are using [Node.js v12 and this has been deprecated by GitHub](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

Additionally, the use of [set-state and set-output has been deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Therefore the workflows are updated to the new version of the actions.