### PR TITLE
Consolidate build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build LDAP SDK
+
+on: [push, pull_request]
+
+jobs:
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
+    secrets: inherit
+
+  build:
+    name: Building LDAP SDK
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build tomcatjss-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+            BUILD_OPTS=--with-timestamp --with-commit-id
+          tags: ldapjdk-runner
+          target: ldapjdk-runner
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=ldapjdk-runner.tar
+
+      - name: Store ldapjdk-runner image
+        uses: actions/cache@v3
+        with:
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,35 +8,29 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building LDAP SDK
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone the repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-            BUILD_OPTS=--with-timestamp --with-commit-id
-          tags: ldapjdk-runner
-          target: ldapjdk-runner
-          outputs: type=docker,dest=sonar-runner.tar
+          ref: ${{ github.ref }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Store runner image
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: sonar-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   sonarcloud:
     name: SonarCloud
@@ -50,14 +44,14 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3
         with:
-          key: sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: sonar-runner.tar
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar
 
-      - name: Load runner image
-        run: docker load --input sonar-runner.tar
+      - name: Load ldapjdk-runner image
+        run: docker load --input ldapjdk-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/ds-tests.yml
+++ b/.github/workflows/ds-tests.yml
@@ -9,35 +9,29 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building LDAP SDK
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone the repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-            BUILD_OPTS=--with-timestamp --with-commit-id
-          tags: ldapjdk-runner
-          target: ldapjdk-runner
-          outputs: type=docker,dest=ds-runner.tar
+          ref: ${{ github.ref }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Store runner image
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: ds-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ds-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ds-test:
     name: Testing DS
@@ -51,14 +45,14 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3
         with:
-          key: ds-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ds-runner.tar
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar
 
-      - name: Load runner image
-        run: docker load --input ds-runner.tar
+      - name: Load ldapjdk-runner image
+        run: docker load --input ldapjdk-runner.tar
 
       - name: Run container
         run: |
@@ -104,14 +98,14 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3
         with:
-          key: ds-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ds-runner.tar
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar
 
-      - name: Load runner image
-        run: docker load --input ds-runner.tar
+      - name: Load ldapjdk-runner image
+        run: docker load --input ldapjdk-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/pki-tests.yml
+++ b/.github/workflows/pki-tests.yml
@@ -9,35 +9,29 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building LDAP SDK
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone the repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-            BUILD_OPTS=--with-timestamp --with-commit-id
-          tags: ldapjdk-runner
-          target: ldapjdk-runner
-          outputs: type=docker,dest=pki-runner.tar
+          ref: ${{ github.ref }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Store runner image
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building LDAP SDK (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ca-test:
     name: Installing CA
@@ -51,14 +45,14 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar
 
-      - name: Load runner image
-        run: docker load --input pki-runner.tar
+      - name: Load ldapjdk-runner image
+        run: docker load --input ldapjdk-runner.tar
 
       - name: Run container
         run: |


### PR DESCRIPTION
The build jobs in test workflows have been consolidated into `build.yml` such that the build will be created just once by the build workflow, and the test workflows will use the same build once it's completed.

https://github.com/lewagon/wait-on-check-action