### PR TITLE
Cache ldapjdk-deps and ldapjdk-builder-deps images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+ldapjdk-builder.tar
+ldapjdk-runner.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,56 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build tomcatjss-runner image
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v3
+        with:
+          key: buildx-${{ matrix.os }}-${{ hashFiles('ldapjdk.spec') }}
+          path: /tmp/.buildx-cache
+
+      - name: Build ldapjdk-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ldapjdk-deps
+          target: ldapjdk-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build ldapjdk-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ldapjdk-builder-deps
+          target: ldapjdk-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build ldapjdk-builder image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ldapjdk-builder
+          target: ldapjdk-builder
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=ldapjdk-builder.tar
+
+      - name: Store ldapjdk-builder image
+        uses: actions/cache@v3
+        with:
+          key: ldapjdk-builder-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-builder.tar
+
+      - name: Build ldapjdk-runner image
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
The build job has been modified to cache the runtime and build dependencies.