### PR TITLE
Add publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish LDAP SDK
+
+on:
+  workflow_run:
+    workflows: [ 'Build LDAP SDK' ]
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
+    secrets: inherit
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+
+  publish:
+    name: Publishing LDAP SDK
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retrieve ldapjdk-builder image
+        uses: actions/cache@v3
+        with:
+          key: ldapjdk-builder-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-builder.tar
+
+      - name: Publish ldapjdk-builder image
+        run: |
+          docker load --input ldapjdk-builder.tar
+          docker tag ldapjdk-builder ghcr.io/${{ github.repository_owner }}/ldapjdk-builder
+          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-builder
+
+      - name: Retrieve ldapjdk-runner image
+        uses: actions/cache@v3
+        with:
+          key: ldapjdk-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-runner.tar
+
+      - name: Publish ldapjdk-runner image
+        run: |
+          docker load --input ldapjdk-runner.tar
+          docker tag ldapjdk-runner ghcr.io/${{ github.repository_owner }}/ldapjdk-runner
+          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-runner


### PR DESCRIPTION
A new job has been added to publish LDAP SDK images to GH Packages after the build job in the master branch is complete.

In my repo the publish job worked like this:
https://github.com/edewata/ldap-sdk/actions/runs/3729497801

and published the following packages:
https://github.com/edewata?tab=packages&repo_name=ldap-sdk
