### PR TITLE
Drop default COPR repo

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -21,9 +21,18 @@ jobs:
 
     - name: Install dependencies
       run: |
-        dnf install -y dnf-plugins-core maven rpm-build
-        dnf copr enable -y ${{ needs.init.outputs.repo }}
-        dnf builddep -y --spec ldapjdk.spec
+        dnf install -y dnf-plugins-core moby-engine maven rpm-build
+        if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
+        dnf builddep -y --skip-unavailable --spec ldapjdk.spec
+      env:
+        COPR_REPO: ${{ needs.init.outputs.repo }}
+
+    - name: Install JSS packages from jss-builder
+      run: |
+        docker pull ghcr.io/dogtagpki/jss-builder:latest
+        docker create --name=jss-builder ghcr.io/dogtagpki/jss-builder:latest
+        docker cp jss-builder:/root/jss/build/RPMS /tmp/RPMS/
+        dnf localinstall -y /tmp/RPMS/*
 
     - name: Build LDAP JDK with Ant
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Publish ldapjdk-builder image
         run: |
           docker load --input ldapjdk-builder.tar
-          docker tag ldapjdk-builder ghcr.io/${{ github.repository_owner }}/ldapjdk-builder
-          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-builder
+          docker tag ldapjdk-builder ghcr.io/${{ github.repository_owner }}/ldapjdk-builder:latest
+          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-builder:latest
 
       - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3
@@ -50,5 +50,5 @@ jobs:
       - name: Publish ldapjdk-runner image
         run: |
           docker load --input ldapjdk-runner.tar
-          docker tag ldapjdk-runner ghcr.io/${{ github.repository_owner }}/ldapjdk-runner
-          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-runner
+          docker tag ldapjdk-runner ghcr.io/${{ github.repository_owner }}/ldapjdk-runner:latest
+          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-runner:latest

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -12,7 +12,7 @@ echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then
-    REPO="@pki/master"
+    REPO=""
 else
     REPO=$(echo "$BASE64_REPO" | base64 -d)
 fi


### PR DESCRIPTION
The CI has been modified to no longer use a COPR repo by default and instead it will install JSS packages from `jss-builder` image.