### PR TITLE
Add ldapjdk-dist image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 ldapjdk-builder.tar
+ldapjdk-dist.tar
 ldapjdk-runner.tar

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -27,11 +27,12 @@ jobs:
       env:
         COPR_REPO: ${{ needs.init.outputs.repo }}
 
-    - name: Install JSS packages from jss-builder
+    - name: Install JSS packages from jss-dist
       run: |
-        docker pull ghcr.io/dogtagpki/jss-builder:latest
-        docker create --name=jss-builder ghcr.io/dogtagpki/jss-builder:latest
-        docker cp jss-builder:/root/jss/build/RPMS /tmp/RPMS/
+        docker pull ghcr.io/dogtagpki/jss-dist:latest
+        docker create --name=jss-dist ghcr.io/dogtagpki/jss-dist:latest
+        docker cp jss-dist:/root/RPMS /tmp/RPMS/
+        docker rm -f jss-dist
         dnf localinstall -y /tmp/RPMS/*
 
     - name: Build LDAP JDK with Ant

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,24 @@ jobs:
           key: ldapjdk-builder-${{ matrix.os }}-${{ github.sha }}
           path: ldapjdk-builder.tar
 
+      - name: Build ldapjdk-dist image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ldapjdk-dist
+          target: ldapjdk-dist
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=ldapjdk-dist.tar
+
+      - name: Store ldapjdk-dist image
+        uses: actions/cache@v3
+        with:
+          key: ldapjdk-dist-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-dist.tar
+
       - name: Build ldapjdk-runner image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retrieve ldapjdk-builder image
+      - name: Retrieve ldapjdk-dist image
         uses: actions/cache@v3
         with:
-          key: ldapjdk-builder-${{ matrix.os }}-${{ github.sha }}
-          path: ldapjdk-builder.tar
+          key: ldapjdk-dist-${{ matrix.os }}-${{ github.sha }}
+          path: ldapjdk-dist.tar
 
-      - name: Publish ldapjdk-builder image
+      - name: Publish ldapjdk-dist image
         run: |
-          docker load --input ldapjdk-builder.tar
-          docker tag ldapjdk-builder ghcr.io/${{ github.repository_owner }}/ldapjdk-builder:latest
-          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-builder:latest
+          docker load --input ldapjdk-dist.tar
+          docker tag ldapjdk-dist ghcr.io/${{ github.repository_owner }}/ldapjdk-dist:latest
+          docker push ghcr.io/${{ github.repository_owner }}/ldapjdk-dist:latest
 
       - name: Retrieve ldapjdk-runner image
         uses: actions/cache@v3


### PR DESCRIPTION
The CI has been modified to store the RPMs in an Alpine-based image and publish it to GH Packages to reduce the size of the distribution.

**Note:** Since this PR depends on [JSS PR #919](https://github.com/dogtagpki/jss/pull/919), currently it uses `edewata/jss-dist`. Once the JSS PR is merged it will be changed to `dogtagpki/jss-dist`.