### PR TITLE
Publish to GitHub Maven registry

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -41,8 +41,8 @@ jobs:
       run: |
         mvn install:install-file \
             -Dfile=/usr/lib/java/jss.jar \
-            -DgroupId=org.dogtagpki \
-            -DartifactId=jss \
+            -DgroupId=org.dogtagpki.jss \
+            -DartifactId=jss-base \
             -Dversion=5.4.0-SNAPSHOT \
             -Dpackaging=jar \
             -DgeneratePom=true
@@ -54,31 +54,31 @@ jobs:
     - name: Compare ldapjdk.jar
       run: |
         jar tvf ~/build/ldapjdk/packages/ldapjdk.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf java-sdk/ldapjdk/target/ldapjdk-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf java-sdk/ldapjdk/target/ldapjdk-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Compare ldapbeans.jar
       run: |
         jar tvf ~/build/ldapjdk/packages/ldapbeans.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf java-sdk/ldapbeans/target/ldapbeans-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf java-sdk/ldapbeans/target/ldapbeans-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Compare ldapfilter.jar
       run: |
         jar tvf ~/build/ldapjdk/packages/ldapfilt.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf java-sdk/ldapfilter/target/ldapfilter-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf java-sdk/ldapfilter/target/ldapfilter-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Compare ldapsp.jar
       run: |
         jar tvf ~/build/ldapjdk/packages/ldapsp.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf java-sdk/ldapsp/target/ldapsp-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf java-sdk/ldapsp/target/ldapsp-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Compare ldaptools.jar
       run: |
         jar tvf ~/build/ldapjdk/packages/ldaptools.jar | awk '{print $8;}' | sort | tee ant.out
-        jar tvf java-sdk/ldaptools/target/ldaptools-5.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
+        jar tvf java-sdk/ldaptools/target/ldaptools-5.4.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v '^META-INF/maven/' | sort > maven.out
         diff ant.out maven.out
 
     - name: Build LDAP JDK RPMs with Ant

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,47 @@ jobs:
     secrets: inherit
     if: vars.REGISTRY != ''
 
-  build:
-    name: Waiting for build
+  publish-maven:
+    name: Publishing Maven artifacts
     needs: init
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Check settings.xml
+        run: |
+          cat ~/.m2/settings.xml
+
+      - name: Update pom.xml
+        run: |
+          sed -i \
+              -e "s/OWNER/$NAMESPACE/g" \
+              -e "s/REPOSITORY/ldap-sdk/g" \
+              pom.xml
+          cat pom.xml
+
+      - name: Publish Maven artifacts
+        run: |
+          mvn \
+              --batch-mode \
+              --update-snapshots \
+              deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  wait-for-images:
+    name: Waiting for container images
+    needs: init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for container images
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
@@ -28,9 +63,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 
-  publish:
-    name: Publishing LDAP SDK
-    needs: [init, build]
+  publish-images:
+    name: Publishing container images
+    needs: [init, wait-for-images]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ TAGS
 Makefile
 now
 target/
+.flattened-pom.xml
 
 # User files that may appear at the root
 **/config/.cache

--- a/java-sdk/ldapbeans/pom.xml
+++ b/java-sdk/ldapbeans/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>java-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ldapbeans</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -23,15 +29,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/java-sdk/ldapfilter/pom.xml
+++ b/java-sdk/ldapfilter/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>java-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ldapfilter</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -23,9 +29,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/java-sdk/ldapjdk/pom.xml
+++ b/java-sdk/ldapjdk/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>java-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ldapjdk</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -23,8 +29,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 

--- a/java-sdk/ldapsp/pom.xml
+++ b/java-sdk/ldapsp/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>java-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ldapsp</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -23,9 +29,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/java-sdk/ldaptools/pom.xml
+++ b/java-sdk/ldaptools/pom.xml
@@ -4,9 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>java-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>ldaptools</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
     <dependencies>
 
@@ -23,15 +29,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -4,9 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
-    <artifactId>java-sdk</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.dogtagpki.ldap-sdk</groupId>
+        <artifactId>ldap-sdk-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>java-sdk-parent</artifactId>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,66 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
-    <artifactId>ldap-sdk</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <groupId>org.dogtagpki.ldap-sdk</groupId>
+    <artifactId>ldap-sdk-parent</artifactId>
+    <version>${revision}</version>
     <packaging>pom</packaging>
+
+    <properties>
+        <revision>5.4.0-SNAPSHOT</revision>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <modules>
         <module>java-sdk</module>
     </modules>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.1.0</version>
+          <configuration>
+            <updatePomFile>true</updatePomFile>
+            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+          </configuration>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>flatten.clean</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
 
 </project>


### PR DESCRIPTION
A new job has been added to build LDAP SDK with Maven and publish the artifacts to GitHub Maven registry. The group ID and artifact ID have been renamed to follow a more commonly used pattern.

Once it's merged, the packages will look like the following:
https://github.com/edewata?tab=packages&repo_name=ldap-sdk