### PR TITLE
Introduce Packit configuration for ldapjdk

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,30 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+specfile_path: ldapjdk.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - ldapjdk.spec
+  - .packit.yaml
+
+# Allow dist git reactions on packit and ckelley commits and PRs
+allowed_pr_authors:
+  - packit
+  - ckelleyRH
+allowed_committers:
+  - packit
+  - ckelleyRH
+
+upstream_package_name: ldap-sdk
+# downstream (Fedora/CentOS) RPM package name
+downstream_package_name: ldapjdk
+# see: https://packit.dev/docs/configuration/#upstream_tag_template
+upstream_tag_template: "v{version}"
+
+jobs:
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-development
+#     - centos-stream-9-x86_64 # When Packit integration with CentOS is avaiable, enable this

--- a/ldapjdk.spec
+++ b/ldapjdk.spec
@@ -25,8 +25,7 @@ Name:             ldapjdk
 
 Summary:          LDAP SDK
 URL:              https://github.com/dogtagpki/ldap-sdk
-License:          MPLv1.1 or GPLv2+ or LGPLv2+
-BuildArch:        noarch
+License:          MPL-1.1 or GPL-2.0-or-later or LGPL-2.1-or-later
 Version:          %{major_version}.%{minor_version}.%{update_version}
 Release:          %{release_number}%{?phase:.}%{?phase}%{?timestamp:.}%{?timestamp}%{?commit_id:.}%{?commit_id}%{?dist}
 
@@ -44,6 +43,11 @@ Source: https://github.com/dogtagpki/ldap-sdk/archive/v%{version}%{?phase:-}%{?p
 #     <version tag> \
 #     > ldap-sdk-VERSION-RELEASE.patch
 # Patch: ldap-sdk-VERSION-RELEASE.patch
+
+BuildArch:        noarch
+%if 0%{?fedora}
+ExclusiveArch:    %{java_arches} noarch
+%endif
 
 ################################################################################
 # Java


### PR DESCRIPTION
I have been conducting a series of tests into using `packit`. I have, locally, been testing `packit` using the CLI from the configuration file in this PR. I was able to successfully perform:

- A `propose_downstream` job, which creates a PR to Fedora for you from the latest upstream release: https://src.fedoraproject.org/rpms/ldapjdk/pull-request/3# 
- A (scratch) `build in-koji`, which conveniently attached itself to the PR

Given that this all looks OK, I would like to proceed to the next step of testing. This involves having the configuration file in the repo and triggering a release. Releasing should automatically trigger the `propose_downstream` job, which should automatically create a PR for Fedora.

We will not accept the PR though, as this will break `rawhide` as `jss` precedes it in the build order.