### PR TITLE
Hard-code version number in pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Makefile
 now
 target/
 .flattened-pom.xml
+*.versionsBackup
 
 # User files that may appear at the root
 **/config/.cache

--- a/java-sdk/ldapbeans/pom.xml
+++ b/java-sdk/ldapbeans/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>java-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ldapbeans</artifactId>

--- a/java-sdk/ldapfilter/pom.xml
+++ b/java-sdk/ldapfilter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>java-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ldapfilter</artifactId>

--- a/java-sdk/ldapjdk/pom.xml
+++ b/java-sdk/ldapjdk/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>java-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ldapjdk</artifactId>

--- a/java-sdk/ldapsp/pom.xml
+++ b/java-sdk/ldapsp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>java-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ldapsp</artifactId>

--- a/java-sdk/ldaptools/pom.xml
+++ b/java-sdk/ldaptools/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>java-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ldaptools</artifactId>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.ldap-sdk</groupId>
         <artifactId>ldap-sdk-parent</artifactId>
-        <version>${revision}</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-sdk-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.ldap-sdk</groupId>
     <artifactId>ldap-sdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>5.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>5.5.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Some build systems require hard-coding the version number in `pom.xml`, so the `revision` property has been replaced with the actual version number. Updating the version number can be done with the following commands:

```
$ mvn versions:set -DnewVersion=<version>
$ mvn versions:commit
```

The `.gitignore` has been updated to ignore the backup files created by this command.