### PR TITLE
spec: set ExclusiveArch on any OS with java_arches

### DIFF
--- a/ldapjdk.spec
+++ b/ldapjdk.spec
@@ -45,7 +45,7 @@ Source: https://github.com/dogtagpki/ldap-sdk/archive/v%{version}%{?phase:-}%{?p
 # Patch: ldap-sdk-VERSION-RELEASE.patch
 
 BuildArch:        noarch
-%if 0%{?fedora}
+%if 0%{?java_arches:1}
 ExclusiveArch:    %{java_arches} noarch
 %endif
 


### PR DESCRIPTION
Fedora builds are not the only ones which no longer build Java for ix86; Fedora ELN and RHEL 10 are following that as well.  This will avoid builds landing on Java-less architecture builders and thereby failing.
