### PR TITLE
Add Maven build test

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -25,8 +25,122 @@ jobs:
           wait-interval: 30
         if: github.event_name == 'pull_request'
 
-  build-test:
-    name: Build Test
+  maven-test:
+    name: Maven Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y maven ant
+
+        # get dependencies from Maven
+        mvn --batch-mode dependency:copy-dependencies
+
+    - name: Build with Maven
+      run: mvn --batch-mode package
+
+    - name: Build with Ant
+      run: |
+        SLF4J_LIB=$(find . -name "slf4j-api-*.jar" -print -quit)
+        echo "SLF4J_LIB: $SLF4J_LIB"
+
+        JSS_LIB=$(find . -name "jss-base-*.jar" -print -quit)
+        echo "JSS_LIB: $JSS_LIB"
+
+        ./build.sh \
+            --slf4j-lib=$SLF4J_LIB \
+            --jss-lib=$JSS_LIB \
+            dist
+
+    - name: Compare ldapjdk.jar
+      run: |
+        jar tvf java-sdk/ldapjdk/target/ldapjdk.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        jar tvf ~/build/ldapjdk/packages/ldapjdk.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee ant.out
+        diff maven.out ant.out
+
+    - name: Compare ldapbeans.jar
+      run: |
+        jar tvf java-sdk/ldapbeans/target/ldapbeans.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        jar tvf ~/build/ldapjdk/packages/ldapbeans.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee ant.out
+        diff maven.out ant.out
+
+    - name: Compare ldapfilter.jar
+      run: |
+        jar tvf java-sdk/ldapfilter/target/ldapfilter.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        jar tvf ~/build/ldapjdk/packages/ldapfilt.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee ant.out
+        diff maven.out ant.out
+
+    - name: Compare ldapsp.jar
+      run: |
+        jar tvf java-sdk/ldapsp/target/ldapsp.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        jar tvf ~/build/ldapjdk/packages/ldapsp.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee ant.out
+        diff maven.out ant.out
+
+    - name: Compare ldaptools.jar
+      run: |
+        jar tvf java-sdk/ldaptools/target/ldaptools.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | grep -v '^META-INF/maven/' \
+            | tee maven.out
+        jar tvf ~/build/ldapjdk/packages/ldaptools.jar \
+            | awk '{print $8;}' \
+            | sort \
+            | grep -v '/$' \
+            | tee ant.out
+        diff maven.out ant.out
+
+    # TODO: Run examples
+
+  rpm-test:
+    name: RPM Test
     needs: wait-for-build
     runs-on: ubuntu-latest
     env:
@@ -51,100 +165,83 @@ jobs:
         IMAGE: ldapjdk-builder
         HOSTNAME: ldapjdk.example.com
 
-    - name: Build with Ant
+    - name: Install RPMs
       run: |
-        docker exec ldapjdk ./build.sh
-
-    - name: Install JSS into local Maven repo
-      run: |
-        # get JSS <major>.<minor>.<update> version
-        JSS_VERSION=$(docker exec ldapjdk rpm -q --qf "%{version}" dogtag-jss)
-
-        docker exec ldapjdk mvn install:install-file \
-            -Dfile=/usr/lib/java/jss.jar \
-            -DgroupId=org.dogtagpki.jss \
-            -DartifactId=jss-base \
-            -Dversion=$JSS_VERSION-SNAPSHOT \
-            -Dpackaging=jar \
-            -DgeneratePom=true
+        docker exec ldapjdk bash -c "dnf localinstall -y build/RPMS/*.rpm"
 
     - name: Build with Maven
       run: |
-        docker exec ldapjdk mvn package
+        docker exec ldapjdk mvn --batch-mode package
 
     - name: Compare ldapjdk.jar
       run: |
         docker exec ldapjdk \
-            jar tvf /root/build/ldapjdk/packages/ldapjdk.jar \
+            jar tvf /usr/share/java/ldapjdk/ldapjdk.jar \
             | awk '{print $8;}' \
             | sort \
-            | tee ldapjdk.ant
+            | tee rpm.out
         docker exec ldapjdk \
             jar tvf java-sdk/ldapjdk/target/ldapjdk.jar \
             | awk '{print $8;}' \
-            | grep -v '^META-INF/maven/' \
             | sort \
-            | tee ldapjdk.maven
-        diff ldapjdk.ant ldapjdk.maven
+            | tee maven.out
+        diff rpm.out maven.out
 
     - name: Compare ldapbeans.jar
       run: |
         docker exec ldapjdk \
-            jar tvf /root/build/ldapjdk/packages/ldapbeans.jar \
+            jar tvf /usr/share/java/ldapjdk/ldapbeans.jar \
             | awk '{print $8;}' \
             | sort \
-            | tee ldapbeans.ant
+            | tee rpm.out
         docker exec ldapjdk \
             jar tvf java-sdk/ldapbeans/target/ldapbeans.jar \
             | awk '{print $8;}' \
-            | grep -v '^META-INF/maven/' \
             | sort \
-            | tee ldapbeans.maven
-        diff ldapbeans.ant ldapbeans.maven
+            | tee maven.out
+        diff rpm.out maven.out
 
     - name: Compare ldapfilter.jar
       run: |
         docker exec ldapjdk \
-            jar tvf /root/build/ldapjdk/packages/ldapfilt.jar \
+            jar tvf /usr/share/java/ldapjdk/ldapfilter.jar \
             | awk '{print $8;}' \
             | sort \
-            | tee ldapfilt.ant
+            | tee rpm.out
         docker exec ldapjdk \
             jar tvf java-sdk/ldapfilter/target/ldapfilter.jar \
             | awk '{print $8;}' \
-            | grep -v '^META-INF/maven/' \
             | sort \
-            | tee ldapfilt.maven
-        diff ldapfilt.ant ldapfilt.maven
+            | tee maven.out
+        diff rpm.out maven.out
 
     - name: Compare ldapsp.jar
       run: |
         docker exec ldapjdk \
-            jar tvf /root/build/ldapjdk/packages/ldapsp.jar \
+            jar tvf /usr/share/java/ldapjdk/ldapsp.jar \
             | awk '{print $8;}' \
             | sort \
-            | tee ldapsp.ant
+            | tee rpm.out
         docker exec ldapjdk \
             jar tvf java-sdk/ldapsp/target/ldapsp.jar \
             | awk '{print $8;}' \
-            | grep -v '^META-INF/maven/' \
             | sort \
-            | tee ldapsp.maven
-        diff ldapsp.ant ldapsp.maven
+            | tee maven.out
+        diff rpm.out maven.out
 
     - name: Compare ldaptools.jar
       run: |
-        docker exec ldapjdk jar tvf /root/build/ldapjdk/packages/ldaptools.jar \
+        docker exec ldapjdk \
+            jar tvf /usr/share/java/ldapjdk/ldaptools.jar \
             | awk '{print $8;}' \
             | sort \
-            | tee ldaptools.ant
+            | tee rpm.out
         docker exec ldapjdk \
             jar tvf java-sdk/ldaptools/target/ldaptools.jar \
             | awk '{print $8;}' \
-            | grep -v '^META-INF/maven/' \
             | sort \
-            | tee ldaptools.maven
-        diff ldaptools.ant ldaptools.maven
+            | tee maven.out
+        diff rpm.out maven.out
 
     - name: Install RPMInspect
       run: |


### PR DESCRIPTION
A new test has been added to build the code with Maven and Ant then verify that the artifacts are identical. In the future the support for Ant will be dropped.

The existing RPM test has been updated to verify that the artifacts built with XMvn and shipped in RPM are identical to the ones built directly with Maven.

The `build.sh` has been updated to provide options to specify the paths to SLF4J and JSS libraries.